### PR TITLE
fix(data): 부산 폴백 안정화 + 전국 신뢰성 스모크 워크플로우

### DIFF
--- a/.github/workflows/nationwide-reliability.yml
+++ b/.github/workflows/nationwide-reliability.yml
@@ -1,0 +1,105 @@
+name: Nationwide Reliability Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      fixture:
+        description: Fixture JSON path
+        required: false
+        default: scripts/fixtures/nationwide-stations.sample.json
+        type: string
+      enforce:
+        description: Enforce threshold (fail workflow on breach)
+        required: false
+        default: false
+        type: boolean
+      max_degraded_ratio:
+        description: Maximum allowed degraded ratio (0.0~1.0)
+        required: false
+        default: "0.20"
+        type: string
+  schedule:
+    # 06:30 KST daily
+    - cron: "30 21 * * *"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Start app
+        run: |
+          PORT=4012 npm run dev > /tmp/next-dev.log 2>&1 &
+          echo "NEXT_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for app ready
+        run: |
+          for i in $(seq 1 120); do
+            if curl -sf "http://127.0.0.1:4012/api/air-quality-latest?stationName=%EC%A4%91%EA%B5%AC" >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Next app did not become ready in time"
+          tail -n 120 /tmp/next-dev.log || true
+          exit 1
+
+      - name: Run nationwide reliability smoke
+        run: |
+          FIXTURE="${{ github.event.inputs.fixture }}"
+          if [ -z "$FIXTURE" ]; then
+            FIXTURE="scripts/fixtures/nationwide-stations.sample.json"
+          fi
+
+          MAX_RATIO="${{ github.event.inputs.max_degraded_ratio }}"
+          if [ -z "$MAX_RATIO" ]; then
+            MAX_RATIO="0.20"
+          fi
+
+          ENFORCE="${{ github.event.inputs.enforce }}"
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            ENFORCE="true"
+          fi
+
+          ARGS=(
+            --base-url "http://127.0.0.1:4012"
+            --fixture "$FIXTURE"
+            --out-dir "output/nationwide-reliability"
+            --max-degraded-ratio "$MAX_RATIO"
+          )
+
+          if [ "$ENFORCE" = "true" ]; then
+            ARGS+=(--enforce)
+          fi
+
+          node scripts/nationwide-reliability-smoke.mjs "${ARGS[@]}"
+
+      - name: Upload reliability report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nationwide-reliability-report
+          path: output/nationwide-reliability/*
+          if-no-files-found: warn
+
+      - name: Stop app
+        if: always()
+        run: |
+          if [ -n "$NEXT_PID" ]; then
+            kill "$NEXT_PID" >/dev/null 2>&1 || true
+          fi
+          echo "--- next-dev.log (tail) ---"
+          tail -n 80 /tmp/next-dev.log || true

--- a/app/api/air-quality-latest/route.ts
+++ b/app/api/air-quality-latest/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from 'next/server';
 import { buildReliabilityMeta, type AirFetchResult } from '@/lib/dailyReportDecision';
 import { corsHeaders } from '@/lib/cors';
+import {
+  buildStationCandidates,
+  inferExpectedSido,
+  isSidoMismatch,
+} from '@/lib/stationResolution';
 
 const DATA_API_URL = process.env.NEXT_PUBLIC_DATA_API_URL || 'https://epi-log-ai.vercel.app';
 const FALLBACK_TEMP = 22;
@@ -12,14 +17,6 @@ const UNKNOWN_STATION_SIGNATURE = {
   pm10_value: 85,
   o3_value: 0.065,
   no2_value: 0.025,
-};
-
-const STATION_HINTS: Record<string, string[]> = {
-  '성남시 분당구': ['정자동', '수내동', '운중동'],
-  분당구: ['정자동', '수내동', '운중동'],
-  판교동: ['운중동', '정자동'],
-  세종시: ['보람동', '아름동', '한솔동', '조치원읍'],
-  세종특별자치시: ['보람동', '아름동', '한솔동', '조치원읍'],
 };
 
 interface AirQualityRaw {
@@ -65,61 +62,6 @@ interface AirQualityView {
   } | null;
 }
 
-function normalizeDongName(name: string) {
-  return name.replace(/^(.+?)\d+동$/, '$1동');
-}
-
-function normalizeSubregionName(name: string) {
-  // Kakao depth3 often includes numeric suffixes like `역삼1동`, `효자동1가`.
-  // Normalize to maximize DB hit rate.
-  return name
-    .replace(/^(.+?)\d+동$/, '$1동')
-    .replace(/^(.+?)\d+가$/, '$1')
-    .replace(/^(.+?)\d+리$/, '$1리');
-}
-
-function buildStationCandidates(rawStation: string): string[] {
-  const cleaned = rawStation.trim().replace(/\s+/g, ' ');
-  const seen = new Set<string>();
-  const candidates: string[] = [];
-
-  const add = (value?: string) => {
-    if (!value) return;
-    const normalized = value.trim().replace(/\s+/g, ' ');
-    if (!normalized || seen.has(normalized)) return;
-    seen.add(normalized);
-    candidates.push(normalized);
-  };
-
-  add(cleaned);
-  add(cleaned.replace(/\s+/g, ''));
-  add(normalizeDongName(cleaned));
-  add(normalizeSubregionName(cleaned));
-
-  const tokens = cleaned.split(' ').filter(Boolean);
-  for (const token of tokens) {
-    add(token);
-    add(normalizeDongName(token));
-    add(normalizeSubregionName(token));
-  }
-
-  if (tokens.length >= 2) {
-    add(tokens[tokens.length - 1]);
-    add(tokens[tokens.length - 2]);
-    add(`${tokens[tokens.length - 2]} ${tokens[tokens.length - 1]}`);
-  }
-
-  const matchedHints = new Set<string>();
-  for (const [key, hints] of Object.entries(STATION_HINTS)) {
-    if (cleaned.includes(key) || tokens.includes(key)) {
-      hints.forEach((hint) => matchedHints.add(hint));
-    }
-  }
-  matchedHints.forEach((hint) => add(hint));
-
-  return candidates;
-}
-
 function isUnknownStationSignature(data: AirQualityRaw | null): boolean {
   if (!data) return false;
   return (
@@ -132,6 +74,7 @@ function isUnknownStationSignature(data: AirQualityRaw | null): boolean {
 
 async function fetchAirDataWithStationFallback(stationName: string): Promise<AirFetchResult> {
   const candidates = buildStationCandidates(stationName);
+  const expectedSido = inferExpectedSido(stationName);
   let fallbackResult: { data: AirQualityRaw; resolvedStation: string } | null = null;
   const unknownSignatureCandidates: string[] = [];
 
@@ -154,6 +97,14 @@ async function fetchAirDataWithStationFallback(stationName: string): Promise<Air
 
       const parsed = (await response.json()) as AirQualityRaw;
       const resolvedStationName = parsed.stationName || candidate;
+
+      if (isSidoMismatch(expectedSido, parsed.sidoName ?? null)) {
+        console.warn(
+          `[BFF] Sido mismatch for candidate "${candidate}" (expected=${expectedSido}, resolved=${parsed.sidoName}), skipping`,
+        );
+        continue;
+      }
+
       if (!fallbackResult) {
         fallbackResult = { data: parsed, resolvedStation: resolvedStationName };
       }

--- a/app/api/daily-report/route.ts
+++ b/app/api/daily-report/route.ts
@@ -2,6 +2,11 @@ import { NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
 import { buildReliabilityMeta, deriveDecisionSignals } from '@/lib/dailyReportDecision';
 import { corsHeaders } from '@/lib/cors';
+import {
+  buildStationCandidates,
+  inferExpectedSido,
+  isSidoMismatch,
+} from '@/lib/stationResolution';
 
 const DATA_API_URL = process.env.NEXT_PUBLIC_DATA_API_URL || 'https://epi-log-ai.vercel.app';
 const AI_API_URL = process.env.NEXT_PUBLIC_AI_API_URL || 'https://epi-log-ai.vercel.app';
@@ -13,14 +18,6 @@ const UNKNOWN_STATION_SIGNATURE = {
   pm10_value: 85,
   o3_value: 0.065,
   no2_value: 0.025,
-};
-
-const STATION_HINTS: Record<string, string[]> = {
-  '성남시 분당구': ['정자동', '수내동', '운중동'],
-  분당구: ['정자동', '수내동', '운중동'],
-  판교동: ['운중동', '정자동'],
-  세종시: ['보람동', '아름동', '한솔동', '조치원읍'],
-  세종특별자치시: ['보람동', '아름동', '한솔동', '조치원읍'],
 };
 
 export const runtime = 'nodejs';
@@ -189,61 +186,6 @@ function normalizeProfileInput(profile?: ProfileInput): Required<Pick<ProfileInp
   };
 }
 
-function normalizeDongName(name: string) {
-  return name.replace(/^(.+?)\d+동$/, '$1동');
-}
-
-function normalizeSubregionName(name: string) {
-  // Kakao depth3 often includes numeric suffixes like `역삼1동`, `효자동1가`.
-  // Normalize to maximize DB hit rate.
-  return name
-    .replace(/^(.+?)\d+동$/, '$1동')
-    .replace(/^(.+?)\d+가$/, '$1')
-    .replace(/^(.+?)\d+리$/, '$1리');
-}
-
-function buildStationCandidates(rawStation: string): string[] {
-  const cleaned = rawStation.trim().replace(/\s+/g, ' ');
-  const seen = new Set<string>();
-  const candidates: string[] = [];
-
-  const add = (value?: string) => {
-    if (!value) return;
-    const normalized = value.trim().replace(/\s+/g, ' ');
-    if (!normalized || seen.has(normalized)) return;
-    seen.add(normalized);
-    candidates.push(normalized);
-  };
-
-  add(cleaned);
-  add(cleaned.replace(/\s+/g, ''));
-  add(normalizeDongName(cleaned));
-  add(normalizeSubregionName(cleaned));
-
-  const tokens = cleaned.split(' ').filter(Boolean);
-  for (const token of tokens) {
-    add(token);
-    add(normalizeDongName(token));
-    add(normalizeSubregionName(token));
-  }
-
-  if (tokens.length >= 2) {
-    add(tokens[tokens.length - 1]);
-    add(tokens[tokens.length - 2]);
-    add(`${tokens[tokens.length - 2]} ${tokens[tokens.length - 1]}`);
-  }
-
-  const matchedHints = new Set<string>();
-  for (const [key, hints] of Object.entries(STATION_HINTS)) {
-    if (cleaned.includes(key) || tokens.includes(key)) {
-      hints.forEach((hint) => matchedHints.add(hint));
-    }
-  }
-  matchedHints.forEach((hint) => add(hint));
-
-  return candidates;
-}
-
 function isUnknownStationSignature(data: AirQualityRaw | null): boolean {
   if (!data) return false;
   return (
@@ -272,6 +214,7 @@ function isUnknownMetricSignature(
 
 async function fetchAirDataWithStationFallback(stationName: string): Promise<AirFetchResult> {
   const candidates = buildStationCandidates(stationName);
+  const expectedSido = inferExpectedSido(stationName);
   let fallbackResult: { data: AirQualityRaw; resolvedStation: string } | null = null;
   const unknownSignatureCandidates: string[] = [];
 
@@ -289,6 +232,14 @@ async function fetchAirDataWithStationFallback(stationName: string): Promise<Air
 
       const parsed = (await response.json()) as AirQualityRaw;
       const resolvedStationName = parsed.stationName || candidate;
+
+      if (isSidoMismatch(expectedSido, parsed.sidoName ?? null)) {
+        console.warn(
+          `[BFF] Sido mismatch for candidate "${candidate}" (expected=${expectedSido}, resolved=${parsed.sidoName}), skipping`,
+        );
+        continue;
+      }
+
       if (!fallbackResult) {
         fallbackResult = { data: parsed, resolvedStation: resolvedStationName };
       }

--- a/app/api/reverse-geocode/route.ts
+++ b/app/api/reverse-geocode/route.ts
@@ -59,14 +59,20 @@ export async function POST(request: Request) {
          );
     }
     
+    const depth1 = (region.region_1depth_name || '').trim();
     const depth2 = (region.region_2depth_name || '').trim();
     const depth3 = (region.region_3depth_name || '').trim();
-    const stationCandidate = [depth2, depth3].filter(Boolean).join(' ').trim() || depth2 || depth3;
+    const stationCandidate =
+      [depth1, depth2, depth3].filter(Boolean).join(' ').trim() ||
+      [depth2, depth3].filter(Boolean).join(' ').trim() ||
+      depth1 ||
+      depth2 ||
+      depth3;
 
     return NextResponse.json({
       address: region.address_name,
       regionName: depth3 || depth2, // 역삼1동 (없으면 강남구)
-      // 2depth만 쓰면 세종시처럼 광역 단위로 고정 템플릿 응답이 나올 수 있어 3depth를 함께 전달
+      // 시도/시군구/동을 함께 넘겨 동일 지명(중구/동구 등)으로 인한 타 시도 오매칭을 줄인다.
       stationCandidate,
     }, { headers: corsHeaders() });
 

--- a/components/LocationHeader.tsx
+++ b/components/LocationHeader.tsx
@@ -17,6 +17,7 @@ interface DaumPostcodeData {
   address: string;
   bname: string;
   sigungu: string;
+  sido?: string;
 }
 
 export default function LocationHeader({ currentLocation, onLocationSelect }: LocationHeaderProps) {
@@ -25,7 +26,7 @@ export default function LocationHeader({ currentLocation, onLocationSelect }: Lo
 
   const handleComplete = (data: DaumPostcodeData) => {
     const displayAddress = data.bname || data.sigungu || data.address;
-    const stationQuery = [data.sigungu, data.bname].filter(Boolean).join(' ').trim();
+    const stationQuery = [data.sido, data.sigungu, data.bname].filter(Boolean).join(' ').trim();
 
     onLocationSelect(displayAddress, stationQuery || displayAddress);
     setIsSearchOpen(false);

--- a/lib/stationResolution.ts
+++ b/lib/stationResolution.ts
@@ -1,0 +1,160 @@
+const STATION_HINTS: Record<string, string[]> = {
+  '성남시 분당구': ['정자동', '수내동', '운중동'],
+  분당구: ['정자동', '수내동', '운중동'],
+  판교동: ['운중동', '정자동'],
+  세종시: ['보람동', '아름동', '한솔동', '조치원읍'],
+  세종특별자치시: ['보람동', '아름동', '한솔동', '조치원읍'],
+  // 부산은 구/동 명칭이 타 시도와 겹치는 경우가 많아 대표 측정소 힌트를 명시한다.
+  '부산광역시 중구': ['광복동'],
+  '부산광역시 서구': ['대신동'],
+  '부산광역시 동구': ['초량동'],
+  '부산광역시 영도구': ['태종대', '청학동'],
+  '부산광역시 부산진구': ['전포동', '개금동'],
+  '부산광역시 동래구': ['명장동'],
+  '부산광역시 남구': ['대연동', '용호동'],
+  '부산광역시 북구': ['화명동', '덕천동'],
+  '부산광역시 해운대구': ['우동', '좌동'],
+  '부산광역시 사하구': ['당리동', '장림동'],
+  '부산광역시 금정구': ['청룡동'],
+  '부산광역시 강서구': ['명지동', '녹산동', '대저동'],
+  '부산광역시 연제구': ['연산동'],
+  '부산광역시 수영구': ['광안동'],
+  '부산광역시 사상구': ['학장동', '삼락동'],
+  '부산광역시 기장군': ['기장읍'],
+  // 주소 검색 소스에 따라 시도명이 `부산`으로만 전달되는 케이스도 함께 처리한다.
+  '부산 중구': ['광복동'],
+  '부산 서구': ['대신동'],
+  '부산 동구': ['초량동'],
+  '부산 영도구': ['태종대', '청학동'],
+  '부산 부산진구': ['전포동', '개금동'],
+  '부산 동래구': ['명장동'],
+  '부산 남구': ['대연동', '용호동'],
+  '부산 북구': ['화명동', '덕천동'],
+  '부산 해운대구': ['우동', '좌동'],
+  '부산 사하구': ['당리동', '장림동'],
+  '부산 금정구': ['청룡동'],
+  '부산 강서구': ['명지동', '녹산동', '대저동'],
+  '부산 연제구': ['연산동'],
+  '부산 수영구': ['광안동'],
+  '부산 사상구': ['학장동', '삼락동'],
+  '부산 기장군': ['기장읍'],
+  // depth1 정보가 없는 기존 stationName 입력과도 호환되도록, 비교적 고유한 구/군 키를 함께 둔다.
+  부산진구: ['전포동', '개금동'],
+  동래구: ['명장동'],
+  영도구: ['태종대', '청학동'],
+  해운대구: ['우동', '좌동'],
+  사하구: ['당리동', '장림동'],
+  금정구: ['청룡동'],
+  연제구: ['연산동'],
+  수영구: ['광안동'],
+  사상구: ['학장동', '삼락동'],
+  기장군: ['기장읍'],
+};
+
+const SIDO_CANONICAL_RULES: Array<{ canonical: string; tokens: string[] }> = [
+  { canonical: '서울', tokens: ['서울특별시', '서울'] },
+  { canonical: '부산', tokens: ['부산광역시', '부산'] },
+  { canonical: '대구', tokens: ['대구광역시', '대구'] },
+  { canonical: '인천', tokens: ['인천광역시', '인천'] },
+  { canonical: '광주', tokens: ['광주광역시', '광주'] },
+  { canonical: '대전', tokens: ['대전광역시', '대전'] },
+  { canonical: '울산', tokens: ['울산광역시', '울산'] },
+  { canonical: '세종', tokens: ['세종특별자치시', '세종시', '세종'] },
+  { canonical: '경기', tokens: ['경기도', '경기'] },
+  { canonical: '강원', tokens: ['강원특별자치도', '강원도', '강원'] },
+  { canonical: '충북', tokens: ['충청북도', '충북'] },
+  { canonical: '충남', tokens: ['충청남도', '충남'] },
+  { canonical: '전북', tokens: ['전북특별자치도', '전라북도', '전북'] },
+  { canonical: '전남', tokens: ['전라남도', '전남'] },
+  { canonical: '경북', tokens: ['경상북도', '경북'] },
+  { canonical: '경남', tokens: ['경상남도', '경남'] },
+  { canonical: '제주', tokens: ['제주특별자치도', '제주도', '제주'] },
+];
+
+export function normalizeDongName(name: string) {
+  return name.replace(/^(.+?)\d+동$/, '$1동');
+}
+
+export function normalizeSubregionName(name: string) {
+  // Kakao depth3 often includes numeric suffixes like `역삼1동`, `효자동1가`.
+  // Normalize to maximize DB hit rate.
+  return name
+    .replace(/^(.+?)\d+동$/, '$1동')
+    .replace(/^(.+?)\d+가$/, '$1')
+    .replace(/^(.+?)\d+리$/, '$1리');
+}
+
+export function buildStationCandidates(rawStation: string): string[] {
+  const cleaned = rawStation.trim().replace(/\s+/g, ' ');
+  const seen = new Set<string>();
+  const candidates: string[] = [];
+
+  const add = (value?: string) => {
+    if (!value) return;
+    const normalized = value.trim().replace(/\s+/g, ' ');
+    if (!normalized || seen.has(normalized)) return;
+    seen.add(normalized);
+    candidates.push(normalized);
+  };
+
+  add(cleaned);
+  add(cleaned.replace(/\s+/g, ''));
+  add(normalizeDongName(cleaned));
+  add(normalizeSubregionName(cleaned));
+
+  const tokens = cleaned.split(' ').filter(Boolean);
+  for (const token of tokens) {
+    add(token);
+    add(normalizeDongName(token));
+    add(normalizeSubregionName(token));
+  }
+
+  if (tokens.length >= 2) {
+    add(tokens[tokens.length - 1]);
+    add(tokens[tokens.length - 2]);
+    add(`${tokens[tokens.length - 2]} ${tokens[tokens.length - 1]}`);
+  }
+
+  const matchedHints = new Set<string>();
+  for (const [key, hints] of Object.entries(STATION_HINTS)) {
+    if (cleaned.includes(key) || tokens.includes(key)) {
+      hints.forEach((hint) => matchedHints.add(hint));
+    }
+  }
+  matchedHints.forEach((hint) => add(hint));
+
+  return candidates;
+}
+
+function canonicalizeSido(value: string): string | null {
+  const compact = value.replace(/\s+/g, '');
+  if (!compact) return null;
+
+  for (const rule of SIDO_CANONICAL_RULES) {
+    if (rule.tokens.some((token) => compact.includes(token.replace(/\s+/g, '')))) {
+      return rule.canonical;
+    }
+  }
+
+  return compact;
+}
+
+export function inferExpectedSido(stationQuery: string): string | null {
+  const compact = stationQuery.replace(/\s+/g, '');
+  if (!compact) return null;
+
+  for (const rule of SIDO_CANONICAL_RULES) {
+    if (rule.tokens.some((token) => compact.includes(token.replace(/\s+/g, '')))) {
+      return rule.canonical;
+    }
+  }
+
+  return null;
+}
+
+export function isSidoMismatch(expectedSido: string | null, resolvedSido?: string | null): boolean {
+  if (!expectedSido || !resolvedSido) return false;
+  const normalizedResolved = canonicalizeSido(resolvedSido);
+  if (!normalizedResolved) return false;
+  return normalizedResolved !== expectedSido;
+}

--- a/miniapps/ait-webview/src/components/LocationHeader.tsx
+++ b/miniapps/ait-webview/src/components/LocationHeader.tsx
@@ -15,6 +15,7 @@ interface DaumPostcodeData {
   address: string;
   bname: string;
   sigungu: string;
+  sido?: string;
 }
 
 export default function LocationHeader({ currentLocation, onLocationSelect }: LocationHeaderProps) {
@@ -26,7 +27,7 @@ export default function LocationHeader({ currentLocation, onLocationSelect }: Lo
 
   const handleComplete = (data: DaumPostcodeData) => {
     const displayAddress = data.bname || data.sigungu || data.address;
-    const stationQuery = [data.sigungu, data.bname].filter(Boolean).join(' ').trim();
+    const stationQuery = [data.sido, data.sigungu, data.bname].filter(Boolean).join(' ').trim();
 
     onLocationSelect(displayAddress, stationQuery || displayAddress);
     setIsSearchOpen(false);

--- a/scripts/fixtures/nationwide-stations.sample.json
+++ b/scripts/fixtures/nationwide-stations.sample.json
@@ -1,0 +1,19 @@
+[
+  { "requestedStation": "서울특별시 강남구 역삼동", "expectedSido": "서울" },
+  { "requestedStation": "부산광역시 해운대구 우동", "expectedSido": "부산" },
+  { "requestedStation": "대구광역시 수성구 지산동", "expectedSido": "대구" },
+  { "requestedStation": "인천광역시 연수구 송도동", "expectedSido": "인천" },
+  { "requestedStation": "광주광역시 북구 용봉동", "expectedSido": "광주" },
+  { "requestedStation": "대전광역시 유성구 봉명동", "expectedSido": "대전" },
+  { "requestedStation": "울산광역시 남구 삼산동", "expectedSido": "울산" },
+  { "requestedStation": "세종특별자치시 아름동", "expectedSido": "세종" },
+  { "requestedStation": "경기도 성남시 분당구 정자동", "expectedSido": "경기" },
+  { "requestedStation": "강원특별자치도 춘천시 석사동", "expectedSido": "강원" },
+  { "requestedStation": "충청북도 청주시 흥덕구 복대동", "expectedSido": "충북" },
+  { "requestedStation": "충청남도 천안시 서북구 불당동", "expectedSido": "충남" },
+  { "requestedStation": "전북특별자치도 전주시 완산구 효자동", "expectedSido": "전북" },
+  { "requestedStation": "전라남도 여수시 학동", "expectedSido": "전남" },
+  { "requestedStation": "경상북도 포항시 남구 대잠동", "expectedSido": "경북" },
+  { "requestedStation": "경상남도 창원시 성산구 중앙동", "expectedSido": "경남" },
+  { "requestedStation": "제주특별자치도 제주시 연동", "expectedSido": "제주" }
+]

--- a/scripts/nationwide-reliability-smoke.mjs
+++ b/scripts/nationwide-reliability-smoke.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+function parseArgs(argv) {
+  const args = {
+    baseUrl: 'http://127.0.0.1:4012',
+    fixture: 'scripts/fixtures/nationwide-stations.sample.json',
+    outDir: 'output/nationwide-reliability',
+    maxDegradedRatio: 0.2,
+    timeoutMs: 15000,
+    enforce: false,
+  };
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--enforce') {
+      args.enforce = true;
+      continue;
+    }
+
+    const value = argv[i + 1];
+    if (!value) continue;
+
+    if (token === '--base-url') {
+      args.baseUrl = value;
+      i += 1;
+    } else if (token === '--fixture') {
+      args.fixture = value;
+      i += 1;
+    } else if (token === '--out-dir') {
+      args.outDir = value;
+      i += 1;
+    } else if (token === '--max-degraded-ratio') {
+      args.maxDegradedRatio = Number(value);
+      i += 1;
+    } else if (token === '--timeout-ms') {
+      args.timeoutMs = Number(value);
+      i += 1;
+    }
+  }
+
+  return args;
+}
+
+function nowStamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function toPercent(value) {
+  return `${(value * 100).toFixed(2)}%`;
+}
+
+function mapStatus(value) {
+  if (value === 'LIVE' || value === 'STATION_FALLBACK' || value === 'DEGRADED') {
+    return value;
+  }
+  return 'REQUEST_FAILED';
+}
+
+function isSidoMismatch(expectedSido, resolvedSido) {
+  if (!expectedSido || !resolvedSido) return false;
+  return expectedSido !== resolvedSido;
+}
+
+function createMarkdown(results, summary) {
+  const lines = [
+    '# Nationwide Reliability Smoke Report',
+    '',
+    `- generatedAt: ${summary.generatedAt}`,
+    `- baseUrl: ${summary.baseUrl}`,
+    `- fixture: ${summary.fixture}`,
+    `- total: ${summary.total}`,
+    `- degradedRatio: ${toPercent(summary.degradedRatio)}`,
+    `- crossSidoMismatchCount: ${summary.crossSidoMismatchCount}`,
+    '',
+    '| requestedStation | expectedSido | status | resolvedStation | resolvedSido | dataTime | triedStations | crossSidoMismatch |',
+    '|---|---|---|---|---|---|---:|---|',
+  ];
+
+  for (const row of results) {
+    lines.push(
+      `| ${row.requestedStation} | ${row.expectedSido || ''} | ${row.status} | ${row.resolvedStation || ''} | ${row.resolvedSido || ''} | ${row.dataTime || ''} | ${row.triedCount} | ${row.crossSidoMismatch ? 'Y' : 'N'} |`,
+    );
+  }
+
+  lines.push('');
+  lines.push('## Status Counts');
+  for (const [status, count] of Object.entries(summary.statusCounts)) {
+    lines.push(`- ${status}: ${count}`);
+  }
+
+  return lines.join('\n');
+}
+
+async function fetchWithTimeout(url, timeoutMs) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { signal: controller.signal, cache: 'no-store' });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  if (!Number.isFinite(args.maxDegradedRatio) || args.maxDegradedRatio < 0 || args.maxDegradedRatio > 1) {
+    throw new Error(`Invalid --max-degraded-ratio: ${args.maxDegradedRatio}`);
+  }
+
+  const fixtureRaw = await readFile(args.fixture, 'utf8');
+  const stations = JSON.parse(fixtureRaw);
+  if (!Array.isArray(stations) || stations.length === 0) {
+    throw new Error(`Fixture must be a non-empty array: ${args.fixture}`);
+  }
+
+  const results = [];
+  for (const entry of stations) {
+    const requestedStation = typeof entry?.requestedStation === 'string' ? entry.requestedStation : '';
+    const expectedSido = typeof entry?.expectedSido === 'string' ? entry.expectedSido : null;
+
+    if (!requestedStation) {
+      results.push({
+        requestedStation: '(invalid fixture row)',
+        expectedSido,
+        status: 'REQUEST_FAILED',
+        resolvedStation: null,
+        resolvedSido: null,
+        dataTime: null,
+        triedCount: 0,
+        crossSidoMismatch: false,
+        error: 'missing requestedStation',
+      });
+      continue;
+    }
+
+    const url = `${args.baseUrl}/api/air-quality-latest?stationName=${encodeURIComponent(requestedStation)}`;
+    try {
+      const response = await fetchWithTimeout(url, args.timeoutMs);
+      if (!response.ok) {
+        results.push({
+          requestedStation,
+          expectedSido,
+          status: 'REQUEST_FAILED',
+          resolvedStation: null,
+          resolvedSido: null,
+          dataTime: null,
+          triedCount: 0,
+          crossSidoMismatch: false,
+          error: `http_${response.status}`,
+        });
+        continue;
+      }
+
+      const payload = await response.json();
+      const reliability = payload?.reliability || {};
+      const air = payload?.airQuality || {};
+      const status = mapStatus(reliability?.status);
+      const resolvedSido = typeof air?.sidoName === 'string' ? air.sidoName : null;
+      const row = {
+        requestedStation,
+        expectedSido,
+        status,
+        resolvedStation: typeof reliability?.resolvedStation === 'string' ? reliability.resolvedStation : null,
+        resolvedSido,
+        dataTime: typeof air?.dataTime === 'string' ? air.dataTime : null,
+        triedCount: Array.isArray(reliability?.triedStations) ? reliability.triedStations.length : 0,
+        crossSidoMismatch: isSidoMismatch(expectedSido, resolvedSido),
+      };
+      results.push(row);
+    } catch (error) {
+      results.push({
+        requestedStation,
+        expectedSido,
+        status: 'REQUEST_FAILED',
+        resolvedStation: null,
+        resolvedSido: null,
+        dataTime: null,
+        triedCount: 0,
+        crossSidoMismatch: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  const statusCounts = results.reduce((acc, row) => {
+    acc[row.status] = (acc[row.status] || 0) + 1;
+    return acc;
+  }, {});
+  const degradedCount = results.filter((row) => row.status === 'DEGRADED').length;
+  const crossSidoMismatchCount = results.filter((row) => row.crossSidoMismatch).length;
+  const degradedRatio = results.length > 0 ? degradedCount / results.length : 0;
+
+  const summary = {
+    generatedAt: new Date().toISOString(),
+    baseUrl: args.baseUrl,
+    fixture: args.fixture,
+    total: results.length,
+    degradedCount,
+    degradedRatio,
+    crossSidoMismatchCount,
+    statusCounts,
+    enforce: args.enforce,
+    maxDegradedRatio: args.maxDegradedRatio,
+  };
+
+  await mkdir(args.outDir, { recursive: true });
+  const stamp = nowStamp();
+  const jsonPath = path.join(args.outDir, `nationwide-reliability-${stamp}.json`);
+  const mdPath = path.join(args.outDir, `nationwide-reliability-${stamp}.md`);
+
+  await writeFile(jsonPath, JSON.stringify({ summary, results }, null, 2), 'utf8');
+  await writeFile(mdPath, createMarkdown(results, summary), 'utf8');
+
+  // Keep CLI output concise for CI logs.
+  console.log(`[reliability] total=${summary.total}`);
+  console.log(`[reliability] degraded=${summary.degradedCount} (${toPercent(summary.degradedRatio)})`);
+  console.log(`[reliability] crossSidoMismatch=${summary.crossSidoMismatchCount}`);
+  console.log(`[reliability] report.json=${jsonPath}`);
+  console.log(`[reliability] report.md=${mdPath}`);
+
+  if (args.enforce) {
+    if (summary.degradedRatio > args.maxDegradedRatio) {
+      throw new Error(
+        `Degraded ratio ${toPercent(summary.degradedRatio)} exceeded max ${toPercent(args.maxDegradedRatio)}`,
+      );
+    }
+    if (summary.crossSidoMismatchCount > 0) {
+      throw new Error(`Cross-sido mismatch detected: ${summary.crossSidoMismatchCount}`);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error('[reliability] failed:', error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/tests/unit/stationResolution.test.ts
+++ b/tests/unit/stationResolution.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildStationCandidates,
+  inferExpectedSido,
+  isSidoMismatch,
+} from '../../lib/stationResolution';
+
+describe('stationResolution', () => {
+  it('부산 구/동 입력에 대표 측정소 힌트를 추가한다', () => {
+    const candidates = buildStationCandidates('부산광역시 부산진구 부전동');
+
+    expect(candidates).toContain('부산광역시 부산진구 부전동');
+    expect(candidates).toContain('전포동');
+    expect(candidates).toContain('개금동');
+  });
+
+  it('기존 분당구 힌트도 유지된다', () => {
+    const candidates = buildStationCandidates('성남시 분당구');
+    expect(candidates).toContain('정자동');
+    expect(candidates).toContain('수내동');
+  });
+
+  it('요청 station query에서 기대 시도를 추론한다', () => {
+    expect(inferExpectedSido('부산광역시 중구 영주동')).toBe('부산');
+    expect(inferExpectedSido('서울특별시 강남구 역삼동')).toBe('서울');
+    expect(inferExpectedSido('중구')).toBeNull();
+  });
+
+  it('시도 불일치 여부를 판별한다', () => {
+    expect(isSidoMismatch('부산', '서울')).toBe(true);
+    expect(isSidoMismatch('부산', '부산광역시')).toBe(false);
+    expect(isSidoMismatch('부산', null)).toBe(false);
+    expect(isSidoMismatch(null, '서울')).toBe(false);
+  });
+});


### PR DESCRIPTION
## 변경 요약
- 부산 지역 측정소 후보 보정 로직을 공통 유틸로 분리하고 힌트를 보강했습니다.
- `daily-report`/`air-quality-latest`에서 시도(`sido`) 불일치 응답을 건너뛰도록 필터링했습니다.
- 역지오코딩/주소검색에서 stationCandidate를 `시도 + 시군구 + 동` 형태로 전달하도록 변경했습니다.
- 전국 단위 신뢰성 점검용 스모크 스크립트와 GitHub Actions 워크플로우를 추가했습니다.

## 주요 파일
- `lib/stationResolution.ts`
- `app/api/daily-report/route.ts`
- `app/api/air-quality-latest/route.ts`
- `app/api/reverse-geocode/route.ts`
- `scripts/nationwide-reliability-smoke.mjs`
- `.github/workflows/nationwide-reliability.yml`

## 검증
- `npm run test:unit`
- `npx eslint app/api/air-quality-latest/route.ts app/api/daily-report/route.ts app/api/reverse-geocode/route.ts components/LocationHeader.tsx miniapps/ait-webview/src/components/LocationHeader.tsx lib/stationResolution.ts tests/unit/stationResolution.test.ts scripts/nationwide-reliability-smoke.mjs .github/workflows/nationwide-reliability.yml`
- 로컬 스모크: `node scripts/nationwide-reliability-smoke.mjs --base-url http://127.0.0.1:4012 --fixture scripts/fixtures/nationwide-stations.sample.json --out-dir output/nationwide-reliability --max-degraded-ratio 1`

## 참고
- 부산 16개 구/군 샘플 재검증 결과: `STATION_FALLBACK 16/16`, `cross-sido mismatch 0`

Closes #21
