### PR TITLE
fix: improve primary station matching precision

### DIFF
--- a/app/api/air-quality-latest/route.ts
+++ b/app/api/air-quality-latest/route.ts
@@ -75,7 +75,7 @@ function isUnknownStationSignature(data: AirQualityRaw | null): boolean {
 async function fetchAirDataWithStationFallback(stationName: string): Promise<AirFetchResult> {
   const candidates = buildStationCandidates(stationName);
   const expectedSido = inferExpectedSido(stationName);
-  let fallbackResult: { data: AirQualityRaw; resolvedStation: string } | null = null;
+  let fallbackResult: { data: AirQualityRaw; resolvedStation: string; candidate: string } | null = null;
   const unknownSignatureCandidates: string[] = [];
 
   for (const candidate of candidates) {
@@ -106,7 +106,7 @@ async function fetchAirDataWithStationFallback(stationName: string): Promise<Air
       }
 
       if (!fallbackResult) {
-        fallbackResult = { data: parsed, resolvedStation: resolvedStationName };
+        fallbackResult = { data: parsed, resolvedStation: resolvedStationName, candidate };
       }
 
       if (isUnknownStationSignature(parsed)) {
@@ -121,8 +121,7 @@ async function fetchAirDataWithStationFallback(stationName: string): Promise<Air
         data: parsed,
         resolvedStation: resolvedStationName,
         triedStations: candidates,
-        usedFallbackCandidate:
-          candidate !== candidates[0] || resolvedStationName !== candidates[0],
+        usedFallbackCandidate: candidate !== candidates[0],
         usedFallbackData: false,
         unknownSignatureCandidates,
       };
@@ -136,7 +135,7 @@ async function fetchAirDataWithStationFallback(stationName: string): Promise<Air
     resolvedStation: fallbackResult?.resolvedStation || stationName,
     triedStations: candidates,
     usedFallbackCandidate: Boolean(
-      fallbackResult && fallbackResult.resolvedStation !== candidates[0],
+      fallbackResult && fallbackResult.candidate !== candidates[0],
     ),
     usedFallbackData: Boolean(fallbackResult),
     unknownSignatureCandidates,

--- a/app/api/daily-report/route.ts
+++ b/app/api/daily-report/route.ts
@@ -215,7 +215,7 @@ function isUnknownMetricSignature(
 async function fetchAirDataWithStationFallback(stationName: string): Promise<AirFetchResult> {
   const candidates = buildStationCandidates(stationName);
   const expectedSido = inferExpectedSido(stationName);
-  let fallbackResult: { data: AirQualityRaw; resolvedStation: string } | null = null;
+  let fallbackResult: { data: AirQualityRaw; resolvedStation: string; candidate: string } | null = null;
   const unknownSignatureCandidates: string[] = [];
 
   for (const candidate of candidates) {
@@ -241,7 +241,7 @@ async function fetchAirDataWithStationFallback(stationName: string): Promise<Air
       }
 
       if (!fallbackResult) {
-        fallbackResult = { data: parsed, resolvedStation: resolvedStationName };
+        fallbackResult = { data: parsed, resolvedStation: resolvedStationName, candidate };
       }
 
       if (isUnknownStationSignature(parsed)) {
@@ -254,8 +254,7 @@ async function fetchAirDataWithStationFallback(stationName: string): Promise<Air
         data: parsed,
         resolvedStation: resolvedStationName,
         triedStations: candidates,
-        usedFallbackCandidate:
-          candidate !== candidates[0] || resolvedStationName !== candidates[0],
+        usedFallbackCandidate: candidate !== candidates[0],
         usedFallbackData: false,
         unknownSignatureCandidates,
       };
@@ -268,7 +267,7 @@ async function fetchAirDataWithStationFallback(stationName: string): Promise<Air
     data: fallbackResult?.data || null,
     resolvedStation: fallbackResult?.resolvedStation || stationName,
     triedStations: candidates,
-    usedFallbackCandidate: Boolean(fallbackResult && fallbackResult.resolvedStation !== candidates[0]),
+    usedFallbackCandidate: Boolean(fallbackResult && fallbackResult.candidate !== candidates[0]),
     usedFallbackData: Boolean(fallbackResult),
     unknownSignatureCandidates,
   };

--- a/lib/stationResolution.ts
+++ b/lib/stationResolution.ts
@@ -2,6 +2,10 @@ const STATION_HINTS: Record<string, string[]> = {
   '성남시 분당구': ['정자동', '수내동', '운중동'],
   분당구: ['정자동', '수내동', '운중동'],
   판교동: ['운중동', '정자동'],
+  // 서울 일부 구는 동 단위보다 구 단위 측정소로 수렴하는 케이스가 있어 우선 힌트를 둔다.
+  '서울특별시 강남구': ['강남구', '역삼동'],
+  '서울 강남구': ['강남구', '역삼동'],
+  강남구: ['강남구', '역삼동'],
   세종시: ['보람동', '아름동', '한솔동', '조치원읍'],
   세종특별자치시: ['보람동', '아름동', '한솔동', '조치원읍'],
   // 전국 단위 신뢰성 스모크에서 DEGRADED가 발생한 지역 우선 보강
@@ -132,12 +136,39 @@ export function buildStationCandidates(rawStation: string): string[] {
     candidates.push(normalized);
   };
 
+  const tokens = cleaned.split(' ').filter(Boolean);
+  const matchedHints: string[] = [];
+  const matchedHintSet = new Set<string>();
+  for (const [key, hints] of Object.entries(STATION_HINTS)) {
+    if (cleaned.includes(key) || tokens.includes(key)) {
+      for (const hint of hints) {
+        if (matchedHintSet.has(hint)) continue;
+        matchedHintSet.add(hint);
+        matchedHints.push(hint);
+      }
+    }
+  }
+
+  const lastToken = tokens.length > 0 ? tokens[tokens.length - 1] : undefined;
+  const prevToken = tokens.length > 1 ? tokens[tokens.length - 2] : undefined;
+
+  // 1차 매칭 성공률 향상을 위해 (힌트 -> 행정동 축약명) 순서로 우선 시도한다.
+  matchedHints.forEach((hint) => add(hint));
+  if (lastToken) {
+    add(normalizeSubregionName(lastToken));
+    add(normalizeDongName(lastToken));
+    add(lastToken);
+  }
+  if (prevToken && lastToken) {
+    add(`${prevToken} ${normalizeSubregionName(lastToken)}`);
+    add(`${prevToken} ${lastToken}`);
+  }
+
   add(cleaned);
   add(cleaned.replace(/\s+/g, ''));
   add(normalizeDongName(cleaned));
   add(normalizeSubregionName(cleaned));
 
-  const tokens = cleaned.split(' ').filter(Boolean);
   for (const token of tokens) {
     add(token);
     add(normalizeDongName(token));
@@ -145,18 +176,8 @@ export function buildStationCandidates(rawStation: string): string[] {
   }
 
   if (tokens.length >= 2) {
-    add(tokens[tokens.length - 1]);
     add(tokens[tokens.length - 2]);
-    add(`${tokens[tokens.length - 2]} ${tokens[tokens.length - 1]}`);
   }
-
-  const matchedHints = new Set<string>();
-  for (const [key, hints] of Object.entries(STATION_HINTS)) {
-    if (cleaned.includes(key) || tokens.includes(key)) {
-      hints.forEach((hint) => matchedHints.add(hint));
-    }
-  }
-  matchedHints.forEach((hint) => add(hint));
 
   return candidates;
 }

--- a/tests/unit/stationResolution.test.ts
+++ b/tests/unit/stationResolution.test.ts
@@ -74,6 +74,21 @@ describe('stationResolution', () => {
     expect(candidates).toContain('수내동');
   });
 
+  it('보정 힌트가 있는 주소는 힌트 후보를 우선 순위로 둔다', () => {
+    const candidates = buildStationCandidates('경상북도 포항시 남구 대잠동');
+    expect(candidates[0]).toBe('장흥동');
+  });
+
+  it('강남구 주소는 구 단위 측정소 힌트를 우선 후보로 둔다', () => {
+    const candidates = buildStationCandidates('서울특별시 강남구 역삼동');
+    expect(candidates[0]).toBe('강남구');
+  });
+
+  it('보정 힌트가 없는 주소는 말단 행정동 후보를 우선 순위로 둔다', () => {
+    const candidates = buildStationCandidates('서울특별시 종로구 사직동');
+    expect(candidates[0]).toBe('사직동');
+  });
+
   it('요청 station query에서 기대 시도를 추론한다', () => {
     expect(inferExpectedSido('부산광역시 중구 영주동')).toBe('부산');
     expect(inferExpectedSido('서울특별시 강남구 역삼동')).toBe('서울');


### PR DESCRIPTION
## Summary\n- reorder station candidate generation to prioritize representative hints and normalized local tokens\n- align fallback classification to candidate index usage (instead of resolved station string equality)\n- add tests for candidate priority, including Gangnam and no-hint scenarios\n\n## Verification\n- npm run test:unit -- tests/unit/stationResolution.test.ts tests/unit/daily-report.route.test.ts\n- nationwide smoke (sample fixture): statusCounts={"LIVE":17}, degradedRatio=0, crossSidoMismatchCount=0\n