### PR TITLE
feat: polish hero controls and settings modal usability

### DIFF
--- a/components/HeroCard.tsx
+++ b/components/HeroCard.tsx
@@ -185,7 +185,7 @@ export default function HeroCard({
       className="col-span-2 min-h-[460px] bento-card relative flex flex-col items-center p-5 md:min-h-[540px] md:p-6"
     >
       <div className="absolute left-5 top-5 z-10 md:left-6 md:top-6">
-        <div className="flex w-[min(270px,calc(100vw-88px))] flex-col gap-2">
+        <div className="inline-grid max-w-[min(290px,calc(100vw-88px))] grid-cols-1 gap-2">
           {onOpenAgeModal && (
             <motion.button
               type="button"
@@ -200,7 +200,7 @@ export default function HeroCard({
               data-testid="hero-age-open"
             >
               <span aria-hidden="true">👶</span>
-              <span className="min-w-0 truncate text-left">{ageSummary}</span>
+              <span className="min-w-0 text-left">{ageSummary}</span>
             </motion.button>
           )}
 
@@ -218,7 +218,7 @@ export default function HeroCard({
               data-testid="hero-condition-open"
             >
               <span aria-hidden="true">🩺</span>
-              <span className="min-w-0 truncate text-left">{conditionSummary || "질환: 해당 없음"}</span>
+              <span className="min-w-0 text-left">{conditionSummary || "질환: 해당 없음"}</span>
             </motion.button>
           )}
         </div>

--- a/components/InsightDrawer.tsx
+++ b/components/InsightDrawer.tsx
@@ -43,7 +43,7 @@ export default function InsightDrawer({
   isLoading = false,
 }: InsightDrawerProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [isDetailExpanded, setIsDetailExpanded] = useState(false);
+  const [isDetailExpanded, setIsDetailExpanded] = useState(true);
   const [feedback, setFeedback] = useState<'helpful' | 'not_helpful' | null>(null);
   const { logEvent } = useLogger();
 

--- a/components/ProfileSettingsModal.tsx
+++ b/components/ProfileSettingsModal.tsx
@@ -166,14 +166,14 @@ export default function ProfileSettingsModal({
             initial={{ opacity: 0, y: 50, scale: 0.9 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 50, scale: 0.9 }}
-            className="relative flex max-h-[min(90vh,800px)] w-full max-w-md flex-col overflow-hidden rounded-[24px] border-[3px] border-black bg-white shadow-bento"
+            className="relative flex max-h-[78vh] w-full max-w-sm flex-col overflow-hidden rounded-[24px] border-[3px] border-black bg-white shadow-bento md:max-h-[700px] md:max-w-md"
             data-testid="settings-modal"
           >
-            <div className="flex-shrink-0 p-8 pb-4">
+            <div className="flex-shrink-0 p-6 pb-3 md:p-7 md:pb-4">
               <button
                 type="button"
                 onClick={onClose}
-                className="absolute right-6 top-6 z-10 rounded-full border-[3px] border-black bg-white p-2 shadow-bento-sm transition-colors hover:bg-gray-100"
+                className="absolute right-5 top-5 z-10 rounded-full border-[3px] border-black bg-white p-2 shadow-bento-sm transition-colors hover:bg-gray-100 md:right-6 md:top-6"
                 aria-label="설정 모달 닫기"
                 data-testid="settings-close"
               >
@@ -214,7 +214,7 @@ export default function ProfileSettingsModal({
               </div>
             </div>
 
-            <div className="flex-1 overflow-y-auto px-8">
+            <div className="flex-1 overflow-y-auto overscroll-contain px-6 pb-1 md:px-7">
               <form id="settings-form" onSubmit={handleSubmit} className="space-y-6 pb-4">
                 {activeTab === 'age' ? (
                   <div>
@@ -315,15 +315,14 @@ export default function ProfileSettingsModal({
               </form>
             </div>
 
-            <div className="flex-shrink-0 p-8 pt-4">
+            <div className="flex-shrink-0 p-6 pt-3 md:p-7 md:pt-4">
               <button
                 type="submit"
                 form="settings-form"
-                className="flex w-full items-center justify-center gap-2 rounded-[24px] border-[3px] border-black bg-[#FEE500] py-5 text-xl font-black text-black shadow-bento transition-all hover:bg-[#FDD835] active:translate-y-1 active:shadow-none"
+                className="flex w-full items-center justify-center rounded-[24px] border-[3px] border-black bg-[#FEE500] py-5 text-xl font-black text-black shadow-bento transition-all hover:bg-[#FDD835] active:translate-y-1 active:shadow-none"
                 data-testid="settings-submit"
               >
                 {activeTab === 'age' ? '연령 저장' : '질환 저장'}
-                <span className="text-2xl">{activeTab === 'age' ? '👶' : '🩺'}</span>
               </button>
             </div>
           </motion.div>

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -298,9 +298,6 @@ test('왜 그런가요 섹션은 3줄 요약과 자세히 보기만 제공하고
   await expect(summaryList.locator('li')).toHaveCount(3);
   await expect(page.getByText('아이를 위해 지금 결정하세요')).toHaveCount(0);
   await expect(detailToggle).toBeVisible();
-  await expect(detailToggle).toHaveAttribute('aria-expanded', 'false');
-
-  await detailToggle.click();
   await expect(detailToggle).toHaveAttribute('aria-expanded', 'true');
   await expect(page.getByTestId('insight-detail-content')).toContainText(
     '실외 활동은 가능하지만 활동량을 중강도로 제한하는 것이 안전해요.',


### PR DESCRIPTION
## 변경 사항
- 히어로 카드의 연령/질환 버튼을 세로 정렬하고 동일한 hug 폭으로 정렬
- 설정 모달 모바일 높이를 축소(`max-h` 조정)하고 내부 스크롤 동작을 강화
- 설정 저장 버튼(`연령 저장`/`질환 저장`)의 이모지 제거
- 상세설명 `자세히 보기`를 기본 확장 상태로 변경
- E2E 기대값을 기본 확장 상태에 맞게 조정

## 검증
- `npx eslint components/HeroCard.tsx components/ProfileSettingsModal.tsx components/InsightDrawer.tsx tests/e2e/home.spec.ts`
- `npx playwright test tests/e2e/home.spec.ts --workers=1 --grep "히어로 카드 질환 선택 버튼으로 모달을 열어 profile.conditions를 갱신한다|히어로 카드 연령 버튼으로 연령 설정 모달을 연다|왜 그런가요 섹션은 3줄 요약과 자세히 보기만 제공하고 중복 액션 카드는 노출하지 않는다" --reporter=line`
