### PR TITLE
fix: use csv reason text without detail fallback

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -761,7 +761,7 @@ export default function Home() {
         <HeroCard
           character={characterPath}
           decisionText={data?.aiGuide?.summary || "지금은 정보를 가져올 수 없어요 😢"}
-          reasonText={data?.aiGuide?.csvReason || data?.aiGuide?.detail}
+          reasonText={data?.aiGuide?.csvReason}
           maskRecommendation={data?.aiGuide?.maskRecommendation}
           grade={data?.airQuality?.grade || "NORMAL"}
           ageSummary={ageSummaryText}


### PR DESCRIPTION
## Summary
- keep only the functional change in app/page.tsx
- remove unrelated large formatting churn
- ensure hero reason text uses csv reason only

## Test
- not run (no behavior change beyond reason text source)