### PR TITLE
chore: remove obsolete clothing preview route

### DIFF
--- a/app/preview/clothing-modal/page.tsx
+++ b/app/preview/clothing-modal/page.tsx
@@ -1,7 +1,0 @@
-"use client";
-
-import HomeScreen from "@/components/HomeScreen";
-
-export default function ClothingModalPreviewPage() {
-  return <HomeScreen enableClothingModalPreview />;
-}


### PR DESCRIPTION
## Summary
- remove obsolete preview route: `/preview/clothing-modal`
- keep home (`/`) as the primary clothing modal experience

## Validation
- route/file cleanup only
