### PR TITLE
feat: 옷차림 모달에 날씨 예보 슬라이드 추가

### DIFF
--- a/app/api/weather-forecast/route.ts
+++ b/app/api/weather-forecast/route.ts
@@ -1,0 +1,438 @@
+import { NextResponse } from 'next/server';
+import { dbConnect } from '@/lib/mongoose';
+import { corsHeaders } from '@/lib/cors';
+import { buildStationCandidates } from '@/lib/stationResolution';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const KST_OFFSET_HOURS = 9;
+const KST_OFFSET_MS = KST_OFFSET_HOURS * 60 * 60 * 1000;
+const FORECAST_WINDOW_HOURS = 48;
+
+interface WeatherForecastRawDoc {
+  stationName?: string;
+  forecastDate?: string;
+  forecastHour?: number | string;
+  forecastTimeLabel?: string;
+  fcstDate?: string;
+  fcstTime?: string;
+  dataTime?: string;
+  temperature?: number | string;
+  humidity?: number | string;
+  precipitation?: number | string | null;
+  precipitationProbability?: number | string | null;
+  precipitationType?: number | string | null;
+  categories?: Record<string, unknown>;
+  updatedAt?: Date | string;
+}
+
+interface WeatherForecastViewItem {
+  forecastAt: string;
+  dateKst: string;
+  hourKst: number;
+  timeLabel: string;
+  temperature: number | null;
+  humidity: number | null;
+  precipitation: number | string | null;
+  precipitationProbability: number | null;
+  precipitationType: number | null;
+  sky: number | null;
+}
+
+interface WeatherForecastViewItemWithUpdatedAt extends WeatherForecastViewItem {
+  updatedAtMs: number;
+}
+
+function parseNumeric(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isNaN(value) ? null : value;
+  }
+
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const parsed = Number(trimmed);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function parseDataTimeToUtc(raw?: string | null): Date | null {
+  if (!raw) return null;
+  const matched = raw.match(/^(\d{4})-(\d{2})-(\d{2})\s+(\d{2}):(\d{2})$/);
+  if (!matched) return null;
+
+  const [, year, month, day, hour, minute] = matched;
+  const utcMillis = Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour) - KST_OFFSET_HOURS,
+    Number(minute),
+  );
+  return Number.isNaN(utcMillis) ? null : new Date(utcMillis);
+}
+
+function parseFcstDateTimeToUtc(fcstDate?: string, fcstTime?: string): Date | null {
+  if (!fcstDate || !fcstTime) return null;
+  if (!/^\d{8}$/.test(fcstDate)) return null;
+  if (!/^\d{3,4}$/.test(fcstTime)) return null;
+
+  const paddedTime = fcstTime.padStart(4, '0');
+  const year = Number(fcstDate.slice(0, 4));
+  const month = Number(fcstDate.slice(4, 6));
+  const day = Number(fcstDate.slice(6, 8));
+  const hour = Number(paddedTime.slice(0, 2));
+  const minute = Number(paddedTime.slice(2, 4));
+
+  const utcMillis = Date.UTC(year, month - 1, day, hour - KST_OFFSET_HOURS, minute);
+  return Number.isNaN(utcMillis) ? null : new Date(utcMillis);
+}
+
+function parseForecastDateHourToUtc(
+  forecastDate?: string,
+  forecastHour?: number | string,
+): Date | null {
+  if (!forecastDate || !/^\d{8}$/.test(forecastDate)) return null;
+
+  const parsedHour = parseNumeric(forecastHour);
+  if (parsedHour === null) return null;
+
+  const year = Number(forecastDate.slice(0, 4));
+  const month = Number(forecastDate.slice(4, 6));
+  const day = Number(forecastDate.slice(6, 8));
+  const hour = Math.round(parsedHour);
+
+  const utcMillis = Date.UTC(year, month - 1, day, hour - KST_OFFSET_HOURS, 0);
+  return Number.isNaN(utcMillis) ? null : new Date(utcMillis);
+}
+
+function parseWeatherAtUtc(doc: WeatherForecastRawDoc): Date | null {
+  return (
+    parseDataTimeToUtc(doc.dataTime) ||
+    parseFcstDateTimeToUtc(doc.fcstDate, doc.fcstTime) ||
+    parseForecastDateHourToUtc(doc.forecastDate, doc.forecastHour)
+  );
+}
+
+function formatKstDate(dateUtc: Date): string {
+  const kstDate = new Date(dateUtc.getTime() + KST_OFFSET_MS);
+  const year = kstDate.getUTCFullYear();
+  const month = `${kstDate.getUTCMonth() + 1}`.padStart(2, '0');
+  const day = `${kstDate.getUTCDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function kstHour(dateUtc: Date): number {
+  const kstDate = new Date(dateUtc.getTime() + KST_OFFSET_MS);
+  return kstDate.getUTCHours();
+}
+
+function formatTimeLabel(hour: number, raw?: string): string {
+  if (typeof raw === 'string' && raw.trim()) return raw.trim();
+  return `${`${hour}`.padStart(2, '0')}:00`;
+}
+
+function parseUpdatedAtMs(value: unknown): number {
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    const parsed = new Date(value).getTime();
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+  return 0;
+}
+
+function normalizePrecipitationType(value: unknown): number | null {
+  const numeric = parseNumeric(value);
+  if (numeric !== null) return Math.round(numeric);
+
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  if (!normalized) return null;
+  if (normalized.includes('없음')) return 0;
+  if (normalized.includes('소나기')) return 4;
+  if (normalized.includes('비/눈') || normalized.includes('비눈')) return 2;
+  if (normalized.includes('눈')) return 3;
+  if (normalized.includes('비')) return 1;
+  return null;
+}
+
+function readCategoryValue(categories: unknown, keys: string[]): unknown {
+  if (!categories || typeof categories !== 'object') return null;
+  const source = categories as Record<string, unknown>;
+
+  for (const key of keys) {
+    const value = source[key] ?? source[key.toLowerCase()] ?? source[key.toUpperCase()];
+    if (value !== undefined) {
+      if (value && typeof value === 'object') {
+        const nested = value as Record<string, unknown>;
+        return nested.fcstValue ?? nested.value ?? nested.code ?? nested.raw ?? value;
+      }
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function mapRawToView(raw: WeatherForecastRawDoc): WeatherForecastViewItemWithUpdatedAt | null {
+  const forecastAt = parseWeatherAtUtc(raw);
+  if (!forecastAt) return null;
+
+  const hourKst = kstHour(forecastAt);
+  const precipitationFromCategory = readCategoryValue(raw.categories, ['PCP']);
+  const precipitationProbabilityFromCategory = readCategoryValue(raw.categories, ['POP']);
+  const precipitationTypeFromCategory = readCategoryValue(raw.categories, ['PTY']);
+  const skyFromCategory = readCategoryValue(raw.categories, ['SKY']);
+
+  const precipitationValue =
+    raw.precipitation !== undefined && raw.precipitation !== null
+      ? raw.precipitation
+      : precipitationFromCategory;
+
+  const precipitation =
+    typeof precipitationValue === 'number'
+      ? precipitationValue
+      : typeof precipitationValue === 'string'
+        ? precipitationValue.trim() || null
+        : null;
+
+  return {
+    forecastAt: forecastAt.toISOString(),
+    dateKst: formatKstDate(forecastAt),
+    hourKst,
+    timeLabel: formatTimeLabel(hourKst, raw.forecastTimeLabel),
+    temperature: parseNumeric(raw.temperature),
+    humidity: parseNumeric(raw.humidity),
+    precipitation,
+    precipitationProbability:
+      parseNumeric(raw.precipitationProbability) ?? parseNumeric(precipitationProbabilityFromCategory),
+    precipitationType:
+      normalizePrecipitationType(raw.precipitationType) ??
+      normalizePrecipitationType(precipitationTypeFromCategory),
+    sky: parseNumeric(skyFromCategory),
+    updatedAtMs: parseUpdatedAtMs(raw.updatedAt),
+  };
+}
+
+function dedupeForecastItems(
+  items: WeatherForecastViewItemWithUpdatedAt[],
+): WeatherForecastViewItemWithUpdatedAt[] {
+  const byTime = new Map<string, WeatherForecastViewItemWithUpdatedAt>();
+
+  for (const item of items) {
+    const existing = byTime.get(item.forecastAt);
+    if (!existing || item.updatedAtMs > existing.updatedAtMs) {
+      byTime.set(item.forecastAt, item);
+    }
+  }
+
+  return Array.from(byTime.values()).sort(
+    (left, right) => Date.parse(left.forecastAt) - Date.parse(right.forecastAt),
+  );
+}
+
+function toKstDateQueryKey(dateUtc: Date): string {
+  const kstDate = new Date(dateUtc.getTime() + KST_OFFSET_MS);
+  const year = kstDate.getUTCFullYear();
+  const month = `${kstDate.getUTCMonth() + 1}`.padStart(2, '0');
+  const day = `${kstDate.getUTCDate()}`.padStart(2, '0');
+  return `${year}${month}${day}`;
+}
+
+async function loadStationForecastDocs(stationName: string): Promise<{
+  station: string | null;
+  docs: WeatherForecastRawDoc[];
+  triedStations: string[];
+}> {
+  const triedStations = buildStationCandidates(stationName);
+  const conn = await dbConnect();
+  const forecastCollection = conn.connection
+    .useDb('weather_forecast')
+    .collection<WeatherForecastRawDoc>('weather_forecast_data');
+
+  const now = new Date();
+  const dateWindowStart = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const dateWindowEnd = new Date(now.getTime() + 72 * 60 * 60 * 1000);
+  const startKey = toKstDateQueryKey(dateWindowStart);
+  const endKey = toKstDateQueryKey(dateWindowEnd);
+
+  let docs = await forecastCollection
+    .find(
+      {
+        stationName: { $in: triedStations },
+        forecastDate: { $gte: startKey, $lte: endKey },
+      },
+      {
+        projection: {
+          _id: 0,
+          stationName: 1,
+          forecastDate: 1,
+          forecastHour: 1,
+          forecastTimeLabel: 1,
+          fcstDate: 1,
+          fcstTime: 1,
+          dataTime: 1,
+          temperature: 1,
+          humidity: 1,
+          precipitation: 1,
+          precipitationProbability: 1,
+          precipitationType: 1,
+          categories: 1,
+          updatedAt: 1,
+        },
+      },
+    )
+    .sort({ forecastDate: 1, forecastHour: 1, updatedAt: -1 })
+    .limit(1200)
+    .toArray();
+
+  if (docs.length === 0) {
+    docs = await forecastCollection
+      .find(
+        {
+          stationName: { $in: triedStations },
+        },
+        {
+          projection: {
+            _id: 0,
+            stationName: 1,
+            forecastDate: 1,
+            forecastHour: 1,
+            forecastTimeLabel: 1,
+            fcstDate: 1,
+            fcstTime: 1,
+            dataTime: 1,
+            temperature: 1,
+            humidity: 1,
+            precipitation: 1,
+            precipitationProbability: 1,
+            precipitationType: 1,
+            categories: 1,
+            updatedAt: 1,
+          },
+        },
+      )
+      .sort({ forecastDate: 1, forecastHour: 1, updatedAt: -1 })
+      .limit(1200)
+      .toArray();
+  }
+
+  if (docs.length === 0) {
+    return { station: null, docs: [], triedStations };
+  }
+
+  const grouped = new Map<string, WeatherForecastRawDoc[]>();
+  for (const doc of docs) {
+    const key = doc.stationName?.trim();
+    if (!key) continue;
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key)!.push(doc);
+  }
+
+  let resolvedStation: string | null = null;
+  for (const candidate of triedStations) {
+    if ((grouped.get(candidate)?.length || 0) > 0) {
+      resolvedStation = candidate;
+      break;
+    }
+  }
+
+  if (!resolvedStation) {
+    const firstGroup = Array.from(grouped.entries()).sort(
+      (left, right) => right[1].length - left[1].length,
+    )[0];
+    resolvedStation = firstGroup ? firstGroup[0] : null;
+  }
+
+  return {
+    station: resolvedStation,
+    docs: resolvedStation ? grouped.get(resolvedStation) || [] : [],
+    triedStations,
+  };
+}
+
+function pickWindowItems(
+  items: WeatherForecastViewItemWithUpdatedAt[],
+): WeatherForecastViewItemWithUpdatedAt[] {
+  const nowMs = Date.now();
+  const endMs = nowMs + FORECAST_WINDOW_HOURS * 60 * 60 * 1000;
+
+  let selected = items.filter((item) => {
+    const itemMs = Date.parse(item.forecastAt);
+    return itemMs >= nowMs && itemMs < endMs;
+  });
+
+  if (selected.length === 0) {
+    selected = items.filter((item) => Date.parse(item.forecastAt) >= nowMs);
+  }
+
+  if (selected.length === 0) {
+    selected = items;
+  }
+
+  return selected.slice(0, FORECAST_WINDOW_HOURS);
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: corsHeaders() });
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const stationName = url.searchParams.get('stationName')?.trim();
+
+  if (!stationName) {
+    return NextResponse.json(
+      { error: 'Missing stationName' },
+      { status: 400, headers: corsHeaders() },
+    );
+  }
+
+  try {
+    const loaded = await loadStationForecastDocs(stationName);
+    const resolvedStation = loaded.station;
+    const mapped = dedupeForecastItems(
+      loaded.docs
+        .map((doc) => mapRawToView(doc))
+        .filter((item): item is WeatherForecastViewItemWithUpdatedAt => item !== null),
+    );
+    const windowed = pickWindowItems(mapped).map((item) => ({
+      forecastAt: item.forecastAt,
+      dateKst: item.dateKst,
+      hourKst: item.hourKst,
+      timeLabel: item.timeLabel,
+      temperature: item.temperature,
+      humidity: item.humidity,
+      precipitation: item.precipitation,
+      precipitationProbability: item.precipitationProbability,
+      precipitationType: item.precipitationType,
+      sky: item.sky,
+    }));
+
+    return NextResponse.json(
+      {
+        requestedStation: stationName,
+        resolvedStation,
+        triedStations: loaded.triedStations,
+        windowHours: FORECAST_WINDOW_HOURS,
+        items: windowed,
+        timestamp: new Date().toISOString(),
+      },
+      {
+        headers: {
+          'Cache-Control': 'no-store, max-age=0',
+          ...corsHeaders(),
+        },
+      },
+    );
+  } catch (error) {
+    console.error('[api/weather-forecast] failed:', error);
+    return NextResponse.json(
+      { error: 'Failed to load weather forecast' },
+      { status: 500, headers: corsHeaders() },
+    );
+  }
+}

--- a/components/ClothingDetailModal.tsx
+++ b/components/ClothingDetailModal.tsx
@@ -1,16 +1,51 @@
 'use client';
 
 import { AnimatePresence, motion } from 'framer-motion';
-import { Droplets, Loader2, RefreshCw, Shirt, Sparkles, Thermometer, X } from 'lucide-react';
+import { type PointerEvent, useRef } from 'react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Cloud,
+  CloudMoon,
+  CloudRain,
+  CloudSnow,
+  CloudSun,
+  Droplets,
+  Loader2,
+  Moon,
+  RefreshCw,
+  Shirt,
+  Sparkles,
+  Sun,
+  Thermometer,
+  X,
+} from 'lucide-react';
+
+const WEEKDAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'] as const;
+
+interface ForecastItem {
+  forecastAt: string;
+  dateKst: string;
+  hourKst: number;
+  temperature: number | null;
+  humidity: number | null;
+  precipitation: number | string | null;
+  precipitationProbability: number | null;
+  precipitationType: number | null;
+  sky: number | null;
+}
 
 interface ClothingDetailModalProps {
   isOpen: boolean;
   isLoading?: boolean;
+  isForecastLoading?: boolean;
   summary?: string;
   recommendation?: string;
   tips?: string[];
   temperature?: number;
   humidity?: number;
+  forecastItems?: ForecastItem[];
+  forecastStationName?: string;
   onRefresh?: () => void;
   onClose: () => void;
 }
@@ -21,23 +56,166 @@ function formatMetric(value: number | undefined, unit: string): string {
   return `${normalized}${unit}`;
 }
 
+function normalizeHour(hour: number): number {
+  const rounded = Math.floor(hour);
+  const normalized = rounded % 24;
+  return normalized >= 0 ? normalized : normalized + 24;
+}
+
+function formatHourLabel(hour: number): string {
+  const normalized = normalizeHour(hour);
+  const period = normalized < 12 ? '오전' : '오후';
+  const hour12 = normalized % 12 === 0 ? 12 : normalized % 12;
+  return `${period} ${hour12}시`;
+}
+
+function formatDateBadge(dateKst: string): string {
+  const matched = dateKst.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!matched) return dateKst;
+  const [, year, month, day] = matched;
+  const dayIndex = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day))).getUTCDay();
+  return `${Number(month)}월 ${Number(day)}일(${WEEKDAY_LABELS[dayIndex]})`;
+}
+
+function formatTemperature(value: number | null | undefined): string {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '-';
+  const normalized = Number.isInteger(value) ? `${value}` : value.toFixed(1).replace(/\.0$/, '');
+  return `${normalized}°`;
+}
+
+function formatProbability(value: number | null | undefined): string | null {
+  if (typeof value !== 'number' || Number.isNaN(value)) return null;
+  return `${Math.round(value)}%`;
+}
+
+function formatPrecipitation(value: number | string | null | undefined): string | null {
+  if (typeof value === 'number' && !Number.isNaN(value)) {
+    return `${value.toFixed(1).replace(/\.0$/, '')}mm`;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+  }
+
+  return null;
+}
+
+function toPrecipitationType(value: number | null | undefined): number {
+  if (typeof value !== 'number' || Number.isNaN(value)) return 0;
+  return Math.round(value);
+}
+
+function ForecastWeatherIcon({ item }: { item: ForecastItem }) {
+  const precipitationType = toPrecipitationType(item.precipitationType);
+  const isNight = item.hourKst < 6 || item.hourKst >= 18;
+
+  if (precipitationType === 1 || precipitationType === 4) {
+    return <CloudRain className="h-7 w-7 text-blue-500" />;
+  }
+
+  if (precipitationType === 2 || precipitationType === 3) {
+    return <CloudSnow className="h-7 w-7 text-cyan-500" />;
+  }
+
+  if (item.sky !== null && item.sky >= 4) {
+    return <Cloud className="h-7 w-7 text-slate-500" />;
+  }
+
+  if (item.sky === 3) {
+    if (isNight) {
+      return <CloudMoon className="h-7 w-7 text-slate-500" />;
+    }
+
+    return <CloudSun className="h-7 w-7 text-slate-500" />;
+  }
+
+  if (isNight) {
+    return <Moon className="h-7 w-7 text-slate-500" />;
+  }
+
+  return <Sun className="h-7 w-7 text-amber-500" />;
+}
+
 export default function ClothingDetailModal({
   isOpen,
   isLoading = false,
+  isForecastLoading = false,
   summary,
   recommendation,
   tips,
   temperature,
   humidity,
+  forecastItems,
+  forecastStationName,
   onRefresh,
   onClose,
 }: ClothingDetailModalProps) {
+  const forecastScrollRef = useRef<HTMLDivElement>(null);
+  const isDragActiveRef = useRef(false);
+  const dragStartXRef = useRef(0);
+  const dragStartScrollLeftRef = useRef(0);
+  const activePointerIdRef = useRef<number | null>(null);
   const displaySummary = summary || '현재 온습도를 바탕으로 옷차림을 정리하고 있어요.';
   const displayRecommendation = recommendation || '얇은 겉옷을 한 겹 챙겨 주세요.';
   const displayTips =
     Array.isArray(tips) && tips.length > 0
       ? tips.slice(0, 3)
       : ['실내외 온도차를 고려해 탈착 가능한 레이어드를 권장해요.'];
+  const displayForecastItems = Array.isArray(forecastItems) ? forecastItems.slice(0, 48) : [];
+
+  const handleSlide = (direction: 1 | -1) => {
+    const container = forecastScrollRef.current;
+    if (!container) return;
+    const moveBy = Math.max(Math.round(container.clientWidth * 0.75), 180);
+    container.scrollBy({ left: direction * moveBy, behavior: 'smooth' });
+  };
+
+  const handleForecastPointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === 'touch') return;
+    if (event.pointerType === 'mouse' && event.button !== 0) return;
+
+    const container = forecastScrollRef.current;
+    if (!container) return;
+
+    isDragActiveRef.current = true;
+    activePointerIdRef.current = event.pointerId;
+    dragStartXRef.current = event.clientX;
+    dragStartScrollLeftRef.current = container.scrollLeft;
+    container.style.scrollBehavior = 'auto';
+    container.classList.remove('cursor-grab');
+    container.classList.add('cursor-grabbing');
+
+    if (container.setPointerCapture) {
+      container.setPointerCapture(event.pointerId);
+    }
+  };
+
+  const handleForecastPointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    if (!isDragActiveRef.current) return;
+    const container = forecastScrollRef.current;
+    if (!container) return;
+
+    const deltaX = event.clientX - dragStartXRef.current;
+    container.scrollLeft = dragStartScrollLeftRef.current - deltaX;
+    event.preventDefault();
+  };
+
+  const handleForecastPointerEnd = () => {
+    if (!isDragActiveRef.current) return;
+    const container = forecastScrollRef.current;
+    isDragActiveRef.current = false;
+
+    if (!container) return;
+    const pointerId = activePointerIdRef.current;
+    if (pointerId !== null && container.releasePointerCapture && container.hasPointerCapture?.(pointerId)) {
+      container.releasePointerCapture(pointerId);
+    }
+    activePointerIdRef.current = null;
+    container.style.scrollBehavior = '';
+    container.classList.remove('cursor-grabbing');
+    container.classList.add('cursor-grab');
+  };
 
   return (
     <AnimatePresence>
@@ -56,7 +234,6 @@ export default function ClothingDetailModal({
           >
             <div className="flex items-center justify-between border-b-2 border-black bg-[#FEE500] px-5 py-4">
               <div>
-                <p className="text-xs font-black tracking-wide text-gray-700">캐릭터 카드 확장</p>
                 <h3 className="text-xl font-black">오늘의 옷차림</h3>
               </div>
               <button
@@ -140,6 +317,100 @@ export default function ClothingDetailModal({
                     </ul>
                   </>
                 )}
+              </div>
+
+              <div className="mt-5 overflow-hidden rounded-2xl border border-gray-200">
+                <div className="flex items-center justify-between border-b border-gray-200 bg-white px-3 py-2 text-gray-900">
+                  <p className="text-xs font-black">날씨 예보</p>
+                  <p className="max-w-[40%] truncate text-[11px] font-semibold text-gray-500">
+                    {forecastStationName || '예보 지역 확인 중'}
+                  </p>
+                </div>
+
+                <div className="relative bg-white px-2 py-2.5">
+                  {isForecastLoading ? (
+                    <div className="flex gap-2 overflow-hidden">
+                      {Array.from({ length: 4 }).map((_, index) => (
+                        <div
+                          key={`forecast-skeleton-${index}`}
+                          className="h-[132px] w-[86px] shrink-0 rounded-lg border border-gray-200 bg-gray-50 p-2"
+                        >
+                          <div className="skeleton-block mb-2 h-3 w-16 rounded" />
+                          <div className="skeleton-block mb-2 h-3 w-12 rounded" />
+                          <div className="skeleton-block mb-3 h-7 w-7 rounded-full" />
+                          <div className="skeleton-block mb-2 h-5 w-10 rounded" />
+                          <div className="skeleton-block h-3 w-14 rounded" />
+                        </div>
+                      ))}
+                    </div>
+                  ) : displayForecastItems.length === 0 ? (
+                    <div className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-3 text-center text-xs font-semibold text-gray-600">
+                      표시할 예보 데이터가 아직 없어요.
+                    </div>
+                  ) : (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => handleSlide(-1)}
+                        className="absolute left-1 top-1/2 z-10 -translate-y-1/2 rounded-full border border-gray-300 bg-white p-1 text-gray-500"
+                        aria-label="이전 예보 보기"
+                      >
+                        <ChevronLeft className="h-4 w-4" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleSlide(1)}
+                        className="absolute right-1 top-1/2 z-10 -translate-y-1/2 rounded-full border border-gray-300 bg-white p-1 text-gray-500"
+                        aria-label="다음 예보 보기"
+                      >
+                        <ChevronRight className="h-4 w-4" />
+                      </button>
+
+                      <div
+                        ref={forecastScrollRef}
+                        onPointerDown={handleForecastPointerDown}
+                        onPointerMove={handleForecastPointerMove}
+                        onPointerUp={handleForecastPointerEnd}
+                        onPointerCancel={handleForecastPointerEnd}
+                        className="cursor-grab overflow-x-auto scroll-smooth [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                      >
+                        <div className="flex min-w-max gap-2 px-7">
+                          {displayForecastItems.map((item, index) => {
+                            const previous = displayForecastItems[index - 1];
+                            const showDateBadge = index === 0 || previous.dateKst !== item.dateKst;
+                            const probability = formatProbability(item.precipitationProbability);
+                            const precipitation = formatPrecipitation(item.precipitation);
+                            return (
+                              <div
+                                key={`${item.forecastAt}-${index}`}
+                                className="w-[86px] shrink-0 rounded-lg border border-gray-200 bg-white px-2 py-2 text-gray-900"
+                              >
+                                <p className="min-h-[14px] text-[10px] font-semibold text-gray-500">
+                                  {showDateBadge ? formatDateBadge(item.dateKst) : '\u00A0'}
+                                </p>
+                                <p className="text-[11px] font-semibold text-gray-500">
+                                  {formatHourLabel(item.hourKst)}
+                                </p>
+                                <div className="mt-1 flex justify-start">
+                                  <ForecastWeatherIcon item={item} />
+                                </div>
+                                <p className="mt-1 text-2xl font-black leading-none">
+                                  {formatTemperature(item.temperature)}
+                                </p>
+                                <p className="mt-1 min-h-[14px] text-[11px] font-semibold text-gray-500">
+                                  {probability || '\u00A0'}
+                                </p>
+                                <p className="min-h-[14px] text-[11px] font-semibold text-gray-500">
+                                  {precipitation || '\u00A0'}
+                                </p>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    </>
+                  )}
+                </div>
               </div>
             </div>
           </motion.div>

--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -58,6 +58,26 @@ interface ClothingRecommendationData {
   source?: string;
 }
 
+interface WeatherForecastItem {
+  forecastAt: string;
+  dateKst: string;
+  hourKst: number;
+  timeLabel: string;
+  temperature: number | null;
+  humidity: number | null;
+  precipitation: number | string | null;
+  precipitationProbability: number | null;
+  precipitationType: number | null;
+  sky: number | null;
+}
+
+interface WeatherForecastData {
+  requestedStation: string;
+  resolvedStation: string | null;
+  items: WeatherForecastItem[];
+  timestamp?: string;
+}
+
 interface HomeProps {
   enableClothingModalPreview?: boolean;
 }
@@ -146,9 +166,12 @@ export default function Home({ enableClothingModalPreview = false }: HomeProps =
   const [clothingData, setClothingData] = useState<ClothingRecommendationData | null>(null);
   const [isClothingLoading, setIsClothingLoading] = useState(false);
   const [isClothingModalOpen, setIsClothingModalOpen] = useState(false);
+  const [forecastData, setForecastData] = useState<WeatherForecastData | null>(null);
+  const [isForecastLoading, setIsForecastLoading] = useState(false);
   const activeControllerRef = useRef<AbortController | null>(null);
   const requestSeqRef = useRef(0);
   const clothingRequestSeqRef = useRef(0);
+  const forecastRequestSeqRef = useRef(0);
   const activeFetchCauseRef = useRef<FetchCause>("initial");
   const loadingStartedAtRef = useRef<number | null>(null);
   const lastFallbackExposeKeyRef = useRef<string | null>(null);
@@ -194,6 +217,41 @@ export default function Home({ enableClothingModalPreview = false }: HomeProps =
       setIsClothingLoading(false);
     }
   }, []);
+
+  const fetchWeatherForecast = useCallback(async (stationName?: string) => {
+    const requestSeq = ++forecastRequestSeqRef.current;
+    const targetStation =
+      typeof stationName === "string" && stationName.trim()
+        ? stationName.trim()
+        : location.stationName.trim();
+
+    if (!targetStation) {
+      if (requestSeq === forecastRequestSeqRef.current) {
+        setForecastData(null);
+        setIsForecastLoading(false);
+      }
+      return;
+    }
+
+    setIsForecastLoading(true);
+    try {
+      const res = await fetch(
+        `/api/weather-forecast?stationName=${encodeURIComponent(targetStation)}`,
+        { cache: "no-store" },
+      );
+      if (!res.ok) throw new Error("Failed to fetch weather forecast");
+
+      const result = (await res.json()) as WeatherForecastData;
+      if (requestSeq !== forecastRequestSeqRef.current) return;
+      setForecastData(result);
+    } catch (error) {
+      if (requestSeq !== forecastRequestSeqRef.current) return;
+      console.error("[UI] Weather forecast fetch failed:", error);
+    } finally {
+      if (requestSeq !== forecastRequestSeqRef.current) return;
+      setIsForecastLoading(false);
+    }
+  }, [location.stationName]);
 
   const fetchData = useCallback(async (
     currentLocation: typeof location,
@@ -641,12 +699,16 @@ export default function Home({ enableClothingModalPreview = false }: HomeProps =
       clothingData?.temperature ?? data?.airQuality?.temp,
       clothingData?.humidity ?? data?.airQuality?.humidity,
     );
+    void fetchWeatherForecast(data?.airQuality?.stationName ?? location.stationName);
   }, [
     clothingData?.humidity,
     clothingData?.temperature,
     data?.airQuality?.humidity,
+    data?.airQuality?.stationName,
     data?.airQuality?.temp,
     fetchClothingRecommendation,
+    fetchWeatherForecast,
+    location.stationName,
   ]);
 
   const handleRefreshClothingModal = useCallback(() => {
@@ -654,12 +716,16 @@ export default function Home({ enableClothingModalPreview = false }: HomeProps =
       clothingData?.temperature ?? data?.airQuality?.temp,
       clothingData?.humidity ?? data?.airQuality?.humidity,
     );
+    void fetchWeatherForecast(data?.airQuality?.stationName ?? location.stationName);
   }, [
     clothingData?.humidity,
     clothingData?.temperature,
     data?.airQuality?.humidity,
+    data?.airQuality?.stationName,
     data?.airQuality?.temp,
     fetchClothingRecommendation,
+    fetchWeatherForecast,
+    location.stationName,
   ]);
 
   const previewClothingButtonLabel = useMemo(() => {
@@ -944,6 +1010,11 @@ export default function Home({ enableClothingModalPreview = false }: HomeProps =
           tips={clothingData?.tips}
           temperature={clothingData?.temperature ?? data?.airQuality?.temp}
           humidity={clothingData?.humidity ?? data?.airQuality?.humidity}
+          isForecastLoading={isForecastLoading}
+          forecastItems={forecastData?.items}
+          forecastStationName={
+            forecastData?.resolvedStation || data?.airQuality?.stationName || location.stationName
+          }
           onRefresh={handleRefreshClothingModal}
         />
       )}


### PR DESCRIPTION
## 변경 내용
- 옷차림 모달 하단에 드래그/버튼 이동 가능한 `날씨 예보` 슬라이드 UI 추가
- MongoDB `weather_forecast.weather_forecast_data` 기반 `GET /api/weather-forecast` API 추가
- 현재 시각 기준 48시간 예보 필터링 및 station 후보 매칭/중복 시각 정리 적용
- 옷차림 모달 오픈/새로고침 시 예보 데이터 연동
- 예보 영역 문구/디자인 단순화(`날씨 예보`, 그레이 톤 보더)

## 확인 사항
- 변경 파일 ESLint 통과
- 전체 레포 lint/tsc는 기존 선행 이슈로 실패(이번 변경 범위 외)
