### PR TITLE
fix: change weather unit label to ℃

### DIFF
--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -740,7 +740,7 @@ export default function Home({ enableClothingModalPreview = false }: HomeProps =
       ? `${currentTemperature}`
       : currentTemperature.toFixed(1).replace(/\.0$/, "");
 
-    return `옷차림\n(현재날씨 ${normalized}도)`;
+    return `옷차림\n(현재날씨 ${normalized} ℃)`;
   }, [clothingData?.temperature, data?.airQuality?.temp, enableClothingModalPreview]);
 
   useEffect(() => {

--- a/miniapps/ait-webview/src/pages/Home.tsx
+++ b/miniapps/ait-webview/src/pages/Home.tsx
@@ -749,7 +749,7 @@ export default function Home() {
       ? `${currentTemperature}`
       : currentTemperature.toFixed(1).replace(/\.0$/, "");
 
-    return `옷차림\n(현재날씨 ${normalized}도)`;
+    return `옷차림\n(현재날씨 ${normalized} ℃)`;
   }, [clothingData?.temperature, data?.airQuality?.temp]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- change clothing button weather label from 현재날씨 ~도 to 현재날씨 ~ ℃
- apply in both Next.js web and apps-in-toss webview pages

## Validation
- npm run lint -- components/HomeScreen.tsx
- cd miniapps/ait-webview && npm run lint -- src/pages/Home.tsx
