### PR TITLE
fix: prevent location fallback after permission granted

### DIFF
--- a/app/api/reverse-geocode/route.ts
+++ b/app/api/reverse-geocode/route.ts
@@ -2,6 +2,87 @@ import { NextResponse } from 'next/server';
 import { corsHeaders } from '@/lib/cors';
 
 const KAKAO_REST_API_KEY = process.env.KAKAO_REST_API_KEY;
+const KAKAO_TIMEOUT_MS = 5000;
+
+interface KakaoRegionDocument {
+  address_name?: string;
+  region_1depth_name?: string;
+  region_2depth_name?: string;
+  region_3depth_name?: string;
+  region_type?: string;
+}
+
+function toCoordinate(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeRegion(doc: KakaoRegionDocument) {
+  const depth1 = (doc.region_1depth_name || '').trim();
+  const depth2 = (doc.region_2depth_name || '').trim();
+  const depth3 = (doc.region_3depth_name || '').trim();
+  const stationCandidate =
+    [depth1, depth2, depth3].filter(Boolean).join(' ').trim() ||
+    [depth2, depth3].filter(Boolean).join(' ').trim() ||
+    depth1 ||
+    depth2 ||
+    depth3;
+  const regionName = depth3 || depth2;
+
+  if (!regionName || !stationCandidate) return null;
+  return {
+    address: doc.address_name,
+    regionName,
+    stationCandidate,
+  };
+}
+
+async function fetchKakaoRegion(lat: number, lng: number): Promise<KakaoRegionDocument | null> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, KAKAO_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(
+      `https://dapi.kakao.com/v2/local/geo/coord2regioncode.json?x=${lng}&y=${lat}`,
+      {
+        headers: {
+          Authorization: `KakaoAK ${KAKAO_REST_API_KEY}`,
+        },
+        signal: controller.signal,
+        cache: 'no-store',
+      },
+    );
+
+    if (!response.ok) {
+      const status = response.status;
+      const bodyText = await response.text().catch(() => '');
+      throw new Error(`KAKAO_HTTP_${status}:${bodyText.slice(0, 200)}`);
+    }
+
+    const data = (await response.json()) as { documents?: KakaoRegionDocument[] };
+    const docs = Array.isArray(data.documents) ? data.documents : [];
+    if (docs.length === 0) return null;
+
+    // Prefer administrative region (H code) when available.
+    return docs.find((doc) => doc.region_type === 'H') || docs[0] || null;
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new Error('KAKAO_TIMEOUT');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
 
 export async function OPTIONS() {
   return new NextResponse(null, { status: 204, headers: corsHeaders() });
@@ -9,11 +90,19 @@ export async function OPTIONS() {
 
 export async function POST(request: Request) {
   try {
-    const { lat, lng } = await request.json();
+    const rawBody = (await request.json()) as { lat?: unknown; lng?: unknown };
+    const lat = toCoordinate(rawBody?.lat);
+    const lng = toCoordinate(rawBody?.lng);
 
-    if (!lat || !lng) {
+    if (lat === null || lng === null) {
       return NextResponse.json(
         { error: 'Latitude and Longitude are required' },
+        { status: 400, headers: corsHeaders() },
+      );
+    }
+    if (lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+      return NextResponse.json(
+        { error: 'Invalid coordinate range' },
         { status: 400, headers: corsHeaders() },
       );
     }
@@ -26,61 +115,50 @@ export async function POST(request: Request) {
       );
     }
 
-    const response = await fetch(
-      `https://dapi.kakao.com/v2/local/geo/coord2regioncode.json?x=${lng}&y=${lat}`,
-      {
-        headers: {
-          Authorization: `KakaoAK ${KAKAO_REST_API_KEY}`,
-        },
-      }
-    );
-
-    if (!response.ok) {
-        const errorData = await response.json();
-        console.error('Kakao API Error:', errorData);
-        throw new Error('Failed to fetch from Kakao API');
-    }
-
-    const data = await response.json();
-    
-    // Kakao returns documents[0] as administrative region (H-Code), documents[1] as legal region (B-Code).
-    // Usually documents[0] (Administrative) is more user-friendly (e.g., Yeoksam 1-dong).
-    // Let's return the full address or just the depth2/depth3 name.
-    // data.documents[0].address_name -> '서울특별시 강남구 역삼1동'
-    // data.documents[0].region_2depth_name -> '강남구'
-    // data.documents[0].region_3depth_name -> '역삼1동'
-
-    const region = data.documents[0];
-    
+    const region = await fetchKakaoRegion(lat, lng);
     if (!region) {
-         return NextResponse.json(
-           { error: 'No results found' },
-           { status: 404, headers: corsHeaders() },
-         );
+      return NextResponse.json(
+        { error: 'UNSUPPORTED_COORDINATES' },
+        { status: 422, headers: corsHeaders() },
+      );
     }
-    
-    const depth1 = (region.region_1depth_name || '').trim();
-    const depth2 = (region.region_2depth_name || '').trim();
-    const depth3 = (region.region_3depth_name || '').trim();
-    const stationCandidate =
-      [depth1, depth2, depth3].filter(Boolean).join(' ').trim() ||
-      [depth2, depth3].filter(Boolean).join(' ').trim() ||
-      depth1 ||
-      depth2 ||
-      depth3;
 
-    return NextResponse.json({
-      address: region.address_name,
-      regionName: depth3 || depth2, // 역삼1동 (없으면 강남구)
-      // 시도/시군구/동을 함께 넘겨 동일 지명(중구/동구 등)으로 인한 타 시도 오매칭을 줄인다.
-      stationCandidate,
-    }, { headers: corsHeaders() });
+    const normalized = normalizeRegion(region);
+    if (!normalized) {
+      return NextResponse.json(
+        { error: 'NO_RESULTS' },
+        { status: 422, headers: corsHeaders() },
+      );
+    }
 
+    return NextResponse.json(
+      {
+        address: normalized.address,
+        regionName: normalized.regionName,
+        stationCandidate: normalized.stationCandidate,
+      },
+      { headers: corsHeaders() },
+    );
   } catch (error) {
     console.error('Reverse Geocode Error:', error);
+
+    const reason = error instanceof Error ? error.message : 'unknown';
+    if (reason.startsWith('KAKAO_HTTP_4')) {
+      return NextResponse.json(
+        { error: 'UNSUPPORTED_COORDINATES' },
+        { status: 422, headers: corsHeaders() },
+      );
+    }
+    if (reason === 'KAKAO_TIMEOUT') {
+      return NextResponse.json(
+        { error: 'UPSTREAM_TIMEOUT' },
+        { status: 504, headers: corsHeaders() },
+      );
+    }
+
     return NextResponse.json(
-      { error: 'Internal Server Error' },
-      { status: 500, headers: corsHeaders() },
+      { error: 'UPSTREAM_ERROR' },
+      { status: 502, headers: corsHeaders() },
     );
   }
 }

--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -33,6 +33,8 @@ const REPORT_TIMEOUT_MS = 25000;
 const FRESHNESS_DELAYED_MINUTES = 60;
 const FRESHNESS_STALE_MINUTES = 90;
 const AIR_LATEST_POLL_INTERVAL_MS = 60_000;
+const REVERSE_GEOCODE_TIMEOUT_MS = 5000;
+const REVERSE_GEOCODE_RETRY_COUNT = 1;
 const DEFAULT_LOCATION_FALLBACK = {
   lat: 37.5172,
   lng: 127.0473,
@@ -81,6 +83,12 @@ interface WeatherForecastData {
   resolvedStation: string | null;
   items: WeatherForecastItem[];
   timestamp?: string;
+}
+
+interface ReverseGeocodeResponse {
+  regionName?: string;
+  stationCandidate?: string;
+  error?: string;
 }
 
 interface HomeProps {
@@ -214,6 +222,60 @@ export default function Home({ enableClothingModalPreview = false }: HomeProps =
     },
     [displayRegion],
   );
+
+  const fetchReverseGeocodeByCoords = useCallback(async (lat: number, lng: number) => {
+    let lastError: unknown = null;
+
+    for (let attempt = 0; attempt <= REVERSE_GEOCODE_RETRY_COUNT; attempt += 1) {
+      const controller = new AbortController();
+      const timeoutId = window.setTimeout(() => {
+        controller.abort();
+      }, REVERSE_GEOCODE_TIMEOUT_MS);
+
+      try {
+        const res = await fetch("/api/reverse-geocode", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ lat, lng }),
+          signal: controller.signal,
+        });
+
+        const payload = (await res.json().catch(() => ({}))) as ReverseGeocodeResponse;
+        if (!res.ok) {
+          const reason = payload.error?.trim() || `HTTP_${res.status}`;
+          const geocodeError = new Error(`reverse_geocode_${reason}`);
+          (geocodeError as { retriable?: boolean }).retriable =
+            res.status >= 500 || res.status === 408 || res.status === 429;
+          throw geocodeError;
+        }
+
+        const regionName = payload.regionName?.trim();
+        const stationCandidate = payload.stationCandidate?.trim();
+        if (!regionName || !stationCandidate) {
+          const geocodeError = new Error("reverse_geocode_invalid_payload");
+          (geocodeError as { retriable?: boolean }).retriable = true;
+          throw geocodeError;
+        }
+
+        return { regionName, stationCandidate };
+      } catch (error) {
+        lastError = error;
+        const isAbortError = error instanceof DOMException && error.name === "AbortError";
+        const retriable =
+          isAbortError ||
+          ((error as { retriable?: boolean } | null)?.retriable ?? true);
+        const isLastAttempt = attempt >= REVERSE_GEOCODE_RETRY_COUNT;
+        if (isLastAttempt || !retriable) break;
+        await new Promise((resolve) => {
+          window.setTimeout(resolve, 150 * (attempt + 1));
+        });
+      } finally {
+        window.clearTimeout(timeoutId);
+      }
+    }
+
+    throw lastError || new Error("reverse_geocode_failed");
+  }, []);
 
   const fetchClothingRecommendation = useCallback(async (
     temperature?: number,
@@ -475,16 +537,10 @@ export default function Home({ enableClothingModalPreview = false }: HomeProps =
 
   const updateLocationByCoords = async (lat: number, lng: number) => {
     try {
-      const res = await fetch("/api/reverse-geocode", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ lat, lng }),
-      });
-
-      if (!res.ok) throw new Error("Geocoding Failed");
-
-      const data = await res.json();
-      const { regionName, stationCandidate } = data;
+      const { regionName, stationCandidate } = await fetchReverseGeocodeByCoords(
+        lat,
+        lng,
+      );
 
       const newLocation = {
         lat,
@@ -499,10 +555,24 @@ export default function Home({ enableClothingModalPreview = false }: HomeProps =
       fetchData(newLocation, profile, "location");
     } catch (error) {
       console.error("Reverse Geocode Error:", error);
+      const reason =
+        error instanceof Error && error.message
+          ? error.message
+          : "unknown";
+      void logEvent("location_reverse_geocode_failed", {
+        reason,
+        lat: Number(lat.toFixed(6)),
+        lng: Number(lng.toFixed(6)),
+      });
       const fallbackLocation = buildLocationFallback({ lat, lng });
       const fallbackRegionLabel = getFallbackRegionLabel(fallbackLocation);
+      const isOutOfCoverage =
+        reason.includes("UNSUPPORTED_COORDINATES") ||
+        reason.includes("NO_RESULTS");
       toast.error(
-        `위치 정보를 불러올 수 없어 '${fallbackRegionLabel}' 기준으로 보여드려요 🏢`,
+        isOutOfCoverage
+          ? `현재 위치는 지원 지역 밖이라 '${fallbackRegionLabel}' 기준으로 보여드려요 🏢`
+          : `위치 정보를 불러올 수 없어 '${fallbackRegionLabel}' 기준으로 보여드려요 🏢`,
       );
       setLocation(fallbackLocation);
       setDisplayRegion(fallbackRegionLabel);

--- a/miniapps/ait-webview/src/pages/Home.tsx
+++ b/miniapps/ait-webview/src/pages/Home.tsx
@@ -34,6 +34,8 @@ const REPORT_TIMEOUT_MS = 25000;
 const FRESHNESS_DELAYED_MINUTES = 60;
 const FRESHNESS_STALE_MINUTES = 90;
 const AIR_LATEST_POLL_INTERVAL_MS = 60_000;
+const REVERSE_GEOCODE_TIMEOUT_MS = 5000;
+const REVERSE_GEOCODE_RETRY_COUNT = 1;
 const DEFAULT_LOCATION_FALLBACK = {
   lat: 37.5172,
   lng: 127.0473,
@@ -83,6 +85,12 @@ interface WeatherForecastData {
   resolvedStation: string | null;
   items: WeatherForecastItem[];
   timestamp?: string;
+}
+
+interface ReverseGeocodeResponse {
+  regionName?: string;
+  stationCandidate?: string;
+  error?: string;
 }
 
 const KNOWN_CONDITION_LABELS: Record<string, string> = {
@@ -217,6 +225,60 @@ export default function Home() {
     },
     [displayRegion],
   );
+
+  const fetchReverseGeocodeByCoords = useCallback(async (lat: number, lng: number) => {
+    let lastError: unknown = null;
+
+    for (let attempt = 0; attempt <= REVERSE_GEOCODE_RETRY_COUNT; attempt += 1) {
+      const controller = new AbortController();
+      const timeoutId = window.setTimeout(() => {
+        controller.abort();
+      }, REVERSE_GEOCODE_TIMEOUT_MS);
+
+      try {
+        const res = await fetch(apiUrl("/api/reverse-geocode"), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ lat, lng }),
+          signal: controller.signal,
+        });
+
+        const payload = (await res.json().catch(() => ({}))) as ReverseGeocodeResponse;
+        if (!res.ok) {
+          const reason = payload.error?.trim() || `HTTP_${res.status}`;
+          const geocodeError = new Error(`reverse_geocode_${reason}`);
+          (geocodeError as { retriable?: boolean }).retriable =
+            res.status >= 500 || res.status === 408 || res.status === 429;
+          throw geocodeError;
+        }
+
+        const regionName = payload.regionName?.trim();
+        const stationCandidate = payload.stationCandidate?.trim();
+        if (!regionName || !stationCandidate) {
+          const geocodeError = new Error("reverse_geocode_invalid_payload");
+          (geocodeError as { retriable?: boolean }).retriable = true;
+          throw geocodeError;
+        }
+
+        return { regionName, stationCandidate };
+      } catch (error) {
+        lastError = error;
+        const isAbortError = error instanceof DOMException && error.name === "AbortError";
+        const retriable =
+          isAbortError ||
+          ((error as { retriable?: boolean } | null)?.retriable ?? true);
+        const isLastAttempt = attempt >= REVERSE_GEOCODE_RETRY_COUNT;
+        if (isLastAttempt || !retriable) break;
+        await new Promise((resolve) => {
+          window.setTimeout(resolve, 150 * (attempt + 1));
+        });
+      } finally {
+        window.clearTimeout(timeoutId);
+      }
+    }
+
+    throw lastError || new Error("reverse_geocode_failed");
+  }, []);
 
   const fetchClothingRecommendation = useCallback(async (temperature?: number, humidity?: number) => {
     const requestSeq = ++clothingRequestSeqRef.current;
@@ -480,16 +542,10 @@ export default function Home() {
 
   const updateLocationByCoords = useCallback(async (lat: number, lng: number) => {
     try {
-      const res = await fetch(apiUrl("/api/reverse-geocode"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ lat, lng }),
-      });
-
-      if (!res.ok) throw new Error("Geocoding Failed");
-
-      const next = await res.json();
-      const { regionName, stationCandidate } = next;
+      const { regionName, stationCandidate } = await fetchReverseGeocodeByCoords(
+        lat,
+        lng,
+      );
 
       const newLocation = {
         lat,
@@ -504,14 +560,30 @@ export default function Home() {
       fetchData(newLocation, profile, "location");
     } catch (error) {
       console.error("Reverse Geocode Error:", error);
+      const reason =
+        error instanceof Error && error.message
+          ? error.message
+          : "unknown";
+      void logEvent("location_reverse_geocode_failed", {
+        reason,
+        lat: Number(lat.toFixed(6)),
+        lng: Number(lng.toFixed(6)),
+      });
       const fallbackLocation = buildLocationFallback({ lat, lng });
       const fallbackRegionLabel = getFallbackRegionLabel(fallbackLocation);
-      toast.error(`위치 정보를 불러올 수 없어 '${fallbackRegionLabel}' 기준으로 보여드려요 🏢`);
+      const isOutOfCoverage =
+        reason.includes("UNSUPPORTED_COORDINATES") ||
+        reason.includes("NO_RESULTS");
+      toast.error(
+        isOutOfCoverage
+          ? `현재 위치는 지원 지역 밖이라 '${fallbackRegionLabel}' 기준으로 보여드려요 🏢`
+          : `위치 정보를 불러올 수 없어 '${fallbackRegionLabel}' 기준으로 보여드려요 🏢`,
+      );
       setLocation(fallbackLocation);
       setDisplayRegion(fallbackRegionLabel);
       fetchData(fallbackLocation, profile, "location");
     }
-  }, [buildLocationFallback, fetchData, getFallbackRegionLabel, profile, setLocation]);
+  }, [buildLocationFallback, fetchReverseGeocodeByCoords, fetchData, getFallbackRegionLabel, logEvent, profile, setLocation]);
 
   const requestCurrentLocation = useCallback(() => {
     if (!navigator.geolocation) {
@@ -534,14 +606,22 @@ export default function Home() {
         console.error("Location permission denied or error:", error);
         if (error?.code === 1) {
           void logAddressConsent(false);
+          setLocationPermissionStatus("denied");
+          toast.error("현재 위치 권한이 없어 기존 지역 기준으로 안내해요.");
+        } else if (error?.code === 3) {
+          // Permission can still be granted, but GPS/IP lookup can time out.
+          setLocationPermissionStatus("idle");
+          toast.error("현재 위치 확인이 지연되어 기존 지역 기준으로 안내해요.");
+        } else {
+          setLocationPermissionStatus("idle");
+          toast.error("현재 위치를 불러오지 못해 기존 지역 기준으로 안내해요.");
         }
-        setLocationPermissionStatus("denied");
-        toast.error("현재 위치 권한이 없어 기존 지역 기준으로 안내해요.");
         setIsRequestingCurrentLocation(false);
       },
       {
-        enableHighAccuracy: true,
-        timeout: 10000,
+        enableHighAccuracy: false,
+        timeout: 15000,
+        maximumAge: 10 * 60 * 1000,
       },
     );
   }, [logAddressConsent, updateLocationByCoords]);


### PR DESCRIPTION
## Root cause
- Permission success was not sufficient: fallback also occurred when reverse-geocode failed.
- reverse-geocode failures were treated as hard 500s (including unsupported coordinates), so client immediately fell back.

## Changes
- add reverse-geocode retry + timeout on client (web + miniapp)
- log reverse-geocode failure reason with coordinates for diagnosis
- improve miniapp geolocation options (reduce timeout false negatives)
- harden reverse-geocode API: numeric/range validation, upstream timeout handling, explicit 422 for unsupported/no-results instead of generic 500

## Validation
- npx eslint app/api/reverse-geocode/route.ts components/HomeScreen.tsx miniapps/ait-webview/src/pages/Home.tsx (warnings only)