### PR TITLE
fix: avoid api/log error loops when MONGODB_URI is missing

### DIFF
--- a/app/api/log/route.ts
+++ b/app/api/log/route.ts
@@ -5,6 +5,19 @@ import { corsHeaders } from '@/lib/cors';
 
 export const runtime = 'nodejs';
 
+let hasWarnedMissingMongoUri = false;
+
+const isMongoConfigured = () => {
+  const uri = process.env.MONGODB_URI;
+  return typeof uri === 'string' && uri.trim().length > 0;
+};
+
+const warnMissingMongoUriOnce = () => {
+  if (hasWarnedMissingMongoUri) return;
+  hasWarnedMissingMongoUri = true;
+  console.warn('[api/log] skip persistence: MONGODB_URI is not configured');
+};
+
 export async function OPTIONS() {
   return new NextResponse(null, { status: 204, headers: corsHeaders() });
 }
@@ -38,6 +51,11 @@ export async function POST(request: Request) {
     );
   }
 
+  if (!isMongoConfigured()) {
+    warnMissingMongoUriOnce();
+    return NextResponse.json({ ok: true, skipped: true }, { status: 202, headers: corsHeaders() });
+  }
+
   try {
     await dbConnect();
 
@@ -67,6 +85,11 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true }, { headers: corsHeaders() });
   } catch (err) {
+    if (err instanceof Error && err.message.includes('Missing env: MONGODB_URI')) {
+      warnMissingMongoUriOnce();
+      return NextResponse.json({ ok: true, skipped: true }, { status: 202, headers: corsHeaders() });
+    }
+
     console.error('[api/log] failed:', err);
     return NextResponse.json({ ok: false }, { status: 500, headers: corsHeaders() });
   }

--- a/tests/unit/log.route.test.ts
+++ b/tests/unit/log.route.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { dbConnectMock, findOneAndUpdateMock } = vi.hoisted(() => ({
+  dbConnectMock: vi.fn(),
+  findOneAndUpdateMock: vi.fn(),
+}));
+
+vi.mock('@/lib/mongoose', () => ({
+  dbConnect: dbConnectMock,
+}));
+
+vi.mock('@/models/UserLog', () => ({
+  UserLog: {
+    findOneAndUpdate: findOneAndUpdateMock,
+  },
+}));
+
+import { POST } from '../../app/api/log/route';
+
+describe('/api/log route', () => {
+  const originalMongoUri = process.env.MONGODB_URI;
+
+  afterEach(() => {
+    dbConnectMock.mockReset();
+    findOneAndUpdateMock.mockReset();
+    vi.restoreAllMocks();
+    process.env.MONGODB_URI = originalMongoUri;
+  });
+
+  it('session_id/event_name이 없으면 400을 반환한다', async () => {
+    process.env.MONGODB_URI = 'mongodb://127.0.0.1:27017/test';
+
+    const request = new Request('http://localhost/api/log', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request);
+    const payload = (await response.json()) as { ok: boolean; error: string };
+
+    expect(response.status).toBe(400);
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toContain('session_id and event_name');
+  });
+
+  it('MONGODB_URI가 없으면 저장을 건너뛰고 202를 반환한다', async () => {
+    delete process.env.MONGODB_URI;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const request = new Request('http://localhost/api/log', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        session_id: 'session-1',
+        event_name: 'landing_view',
+      }),
+    });
+
+    const response = await POST(request);
+    const payload = (await response.json()) as { ok: boolean; skipped?: boolean };
+
+    expect(response.status).toBe(202);
+    expect(payload.ok).toBe(true);
+    expect(payload.skipped).toBe(true);
+    expect(dbConnectMock).not.toHaveBeenCalled();
+    expect(findOneAndUpdateMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('MONGODB_URI가 있으면 로그를 upsert한다', async () => {
+    process.env.MONGODB_URI = 'mongodb://127.0.0.1:27017/test';
+    dbConnectMock.mockResolvedValue({});
+    findOneAndUpdateMock.mockResolvedValue({});
+
+    const request = new Request('http://localhost/api/log', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        session_id: 'session-2',
+        source: 'ref-test',
+        shared_by: 'share-1',
+        event_name: 'landing_view',
+        metadata: { foo: 'bar' },
+      }),
+    });
+
+    const response = await POST(request);
+    const payload = (await response.json()) as { ok: boolean };
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(dbConnectMock).toHaveBeenCalledTimes(1);
+    expect(findOneAndUpdateMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- return `202 { ok: true, skipped: true }` from `/api/log` when `MONGODB_URI` is not configured
- log a warning only once to avoid repeated noisy stack traces during E2E/dev runs
- add unit tests for validation error, missing-Mongo skip path, and normal upsert path

## Test
- npm run lint -- app/api/log/route.ts tests/unit/log.route.test.ts
- npm run test:unit -- tests/unit/log.route.test.ts
