### PR TITLE
perf: tune daily-report ai timeout policy defaults

### DIFF
--- a/app/api/daily-report/route.ts
+++ b/app/api/daily-report/route.ts
@@ -29,17 +29,18 @@ function parseNonNegativeIntEnv(value: string | undefined, fallback: number): nu
 
 const AI_BFF_CACHE_TTL_MS = parsePositiveIntEnv(process.env.DAILY_REPORT_AI_CACHE_TTL_MS, 5 * 60 * 1000);
 const AI_BFF_CACHE_MAX_ENTRIES = parsePositiveIntEnv(process.env.DAILY_REPORT_AI_CACHE_MAX_ENTRIES, 200);
-const AI_PRIMARY_TIMEOUT_MS = parsePositiveIntEnv(process.env.DAILY_REPORT_AI_TIMEOUT_MS, 3200);
+// Increase primary timeout to absorb frequent AI cold misses before fallbacking.
+const AI_PRIMARY_TIMEOUT_MS = parsePositiveIntEnv(process.env.DAILY_REPORT_AI_TIMEOUT_MS, 6500);
 const AI_PRIMARY_RETRY_COUNT = parseNonNegativeIntEnv(process.env.DAILY_REPORT_AI_PRIMARY_RETRY_COUNT, 1);
 const AI_PRIMARY_RETRY_TIMEOUT_MS = parsePositiveIntEnv(
   process.env.DAILY_REPORT_AI_PRIMARY_RETRY_TIMEOUT_MS,
-  AI_PRIMARY_TIMEOUT_MS,
+  1200,
 );
 const AI_PRIMARY_RETRY_BACKOFF_MS = parseNonNegativeIntEnv(
   process.env.DAILY_REPORT_AI_PRIMARY_RETRY_BACKOFF_MS,
-  200,
+  100,
 );
-const AI_RETRY_TIMEOUT_MS = parsePositiveIntEnv(process.env.DAILY_REPORT_AI_RETRY_TIMEOUT_MS, 1400);
+const AI_RETRY_TIMEOUT_MS = parsePositiveIntEnv(process.env.DAILY_REPORT_AI_RETRY_TIMEOUT_MS, 900);
 const AIR_PRIMARY_TIMEOUT_MS = parsePositiveIntEnv(process.env.DAILY_REPORT_AIR_TIMEOUT_MS, 1200);
 const AIR_FETCH_TOTAL_BUDGET_MS = parsePositiveIntEnv(process.env.DAILY_REPORT_AIR_TOTAL_BUDGET_MS, 2400);
 const AIR_FETCH_MAX_CANDIDATES = parsePositiveIntEnv(process.env.DAILY_REPORT_AIR_MAX_CANDIDATES, 6);


### PR DESCRIPTION
## Summary\n- raise default AI primary timeout in daily-report from 3200ms to 6500ms\n- tune retry defaults to keep tail bounded (retry timeout 1200ms, backoff 100ms)\n- lower resolved-station retry timeout to 900ms\n\n## Test\n- npm run test:unit -- tests/unit/daily-report.ai-retry.test.ts