### PR TITLE
fix: prevent api observability wrapper from crashing route handlers

### DIFF
--- a/lib/api-observability.ts
+++ b/lib/api-observability.ts
@@ -85,11 +85,8 @@ function withRequestIdHeader(response: Response, requestId: string): Response {
 export function withApiObservability(route: string, method: string, handler: ApiHandler): ApiHandler {
   return async (request: Request) => {
     const requestId = request.headers.get('x-request-id') || randomUUID();
-    const requestHeaders = new Headers(request.headers);
-    requestHeaders.set('x-request-id', requestId);
-    const observedRequest = new Request(request, { headers: requestHeaders });
     const startedAt = Date.now();
-    const url = new URL(observedRequest.url);
+    const url = new URL(request.url);
     const path = url.pathname;
 
     addSentryBreadcrumb({
@@ -110,7 +107,7 @@ export function withApiObservability(route: string, method: string, handler: Api
     });
 
     try {
-      const response = await handler(observedRequest);
+      const response = await handler(request);
       const durationMs = Date.now() - startedAt;
       const level = statusToLevel(response.status);
 


### PR DESCRIPTION
## Summary
- fix runtime crash in `withApiObservability` caused by `new Request(request, { headers })`
- use original `request` object for URL parsing and handler invocation
- keep `x-request-id` response header behavior unchanged

## Root cause
`new Request(request, { headers })` throws `TypeError: Cannot read private member #state from an object whose class did not declare it` in this runtime.
Because this happens before handler logic runs, wrapped API routes returned 500 immediately.

## Verification
- `npx eslint lib/api-observability.ts`
- `npx vitest run tests/unit/log.route.test.ts tests/unit/daily-report.ai-retry.test.ts`
- local endpoint re-check:
  - `POST /api/daily-report` -> 200
  - `POST /api/reverse-geocode` -> 200
  - `POST /api/clothing-recommendation` -> 200
  - `OPTIONS /api/*` -> 204
