### PR TITLE
fix: let public-data CLI exit after ingest completes

### DIFF
--- a/workers/public-data/src/cli.ts
+++ b/workers/public-data/src/cli.ts
@@ -2,17 +2,24 @@ import { handler as airKoreaHandler } from './airkorea/handler';
 import { handler as airKoreaForecastHandler } from './airkorea-forecast/handler';
 import { handler as kmaShortForecastHandler } from './kma-short-forecast/handler';
 import { handler as kmaLifestyleHandler } from './kma-lifestyle/handler';
-import type { ScheduledIngestEvent } from './shared/types';
+import { closeMongoClient } from './shared/mongo';
+import type { ScheduledIngestEvent, ScheduledIngestJob } from './shared/types';
+
+const SUPPORTED_JOBS: ScheduledIngestJob[] = [
+  'airkorea-realtime',
+  'airkorea-forecast',
+  'kma-short-forecast',
+  'kma-lifestyle',
+];
 
 type CliArgs = {
-  job: string;
+  job?: ScheduledIngestJob;
   dryRun: boolean;
   scope?: string[];
 };
 
 function parseArgs(argv: string[]): CliArgs {
   const args: CliArgs = {
-    job: '',
     dryRun: false,
   };
 
@@ -21,7 +28,11 @@ function parseArgs(argv: string[]): CliArgs {
     const value = argv[index + 1];
 
     if (token === '--job' && value) {
-      args.job = value.trim();
+      const normalized = value.trim();
+      if (!SUPPORTED_JOBS.includes(normalized as ScheduledIngestJob)) {
+        throw new Error(`Unsupported job: ${normalized}`);
+      }
+      args.job = normalized as ScheduledIngestJob;
       index += 1;
       continue;
     }
@@ -56,14 +67,22 @@ async function run(event: ScheduledIngestEvent) {
 }
 
 async function main() {
-  const args = parseArgs(process.argv);
-  const result = await run({
-    job: args.job,
-    trigger: 'github-actions',
-    dryRun: args.dryRun,
-    scope: args.scope,
-  });
-  console.log(JSON.stringify(result, null, 2));
+  try {
+    const args = parseArgs(process.argv);
+    const job = args.job;
+    if (!job) {
+      throw new Error('Missing required --job');
+    }
+    const result = await run({
+      job,
+      trigger: 'github-actions',
+      dryRun: args.dryRun,
+      scope: args.scope,
+    });
+    console.log(JSON.stringify(result, null, 2));
+  } finally {
+    await closeMongoClient();
+  }
 }
 
 main().catch((error) => {

--- a/workers/public-data/src/shared/mongo.ts
+++ b/workers/public-data/src/shared/mongo.ts
@@ -10,6 +10,14 @@ export async function getMongoClient() {
   return clientPromise;
 }
 
+export async function closeMongoClient() {
+  if (!clientPromise) return;
+
+  const client = await clientPromise;
+  clientPromise = null;
+  await client.close();
+}
+
 export async function getCollection<T extends Document>(dbName: string, collectionName: string) {
   const client = await getMongoClient();
   return client.db(dbName).collection<T>(collectionName);


### PR DESCRIPTION
## Summary
- close the shared Mongo client in the public-data CLI so manual workflow runs exit cleanly after success
- keep worker output unchanged while preventing GitHub Actions jobs from hanging until timeout

## Verification
- cd workers/public-data && npm run build
- npm run run:job -- --job airkorea-realtime --scope 서울 --dry-run